### PR TITLE
Fix some bugs with updating applications

### DIFF
--- a/src/repository/job_application_model.rs
+++ b/src/repository/job_application_model.rs
@@ -30,7 +30,7 @@ impl Into<Params> for &JobApplication {
             "job_title" => &self.job_title,
             "application_date" => &self.application_date,
             "time_investment" => &self.time_investment,
-            "automated_response" => &self.automated_response,
+            "automated_response" => if self.automated_response {"Y"} else {"N"},
             "human_response" => &self.human_response,
             "human_response_date" => &self.human_response_date,
             "application_website" => &self.application_website,
@@ -129,7 +129,9 @@ impl Into<Value> for JobApplicationField {
             JobApplicationField::JobTitle(o) => Into::<Value>::into(o),
             JobApplicationField::ApplicationDate(o) => Into::<Value>::into(o),
             JobApplicationField::TimeInvestment(o) => Into::<Value>::into(o),
-            JobApplicationField::AutomatedResponse(o) => Into::<Value>::into(o),
+            JobApplicationField::AutomatedResponse(o) => {
+                Into::<Value>::into(if o { "Y" } else { "N" })
+            }
             JobApplicationField::HumanResponse(o) => Into::<Value>::into(o),
             JobApplicationField::HumanResponseDate(o) => Into::<Value>::into(o),
             JobApplicationField::ApplicationWebsite(o) => Into::<Value>::into(o),

--- a/src/repository/job_application_repository.rs
+++ b/src/repository/job_application_repository.rs
@@ -108,8 +108,8 @@ pub fn update_human_response<C: Queryable>(
 pub fn update_job_application<C: Queryable>(
     conn: &mut C,
     partial_application: PartialJobApplication,
-) -> Result<JobApplication, Box<dyn std::error::Error>> {
-    let mut query_builder = "UPDATE job_applications SET ".to_owned();
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut query_builder = "UPDATE job_applications".to_owned();
 
     // Loop over all field names
     // Flag for if this is the first variable
@@ -119,7 +119,7 @@ pub fn update_job_application<C: Queryable>(
             // NO-OP: Id is special because we are using it in the WHERE clause instead of SET
         } else if is_first {
             // The first non-id value is special because of where the SET and commas are
-            query_builder += &format!("SET {0} = :{0}", field.name());
+            query_builder += &format!(" SET {0} = :{0}", field.name());
             is_first = false
         } else {
             // Normal placement
@@ -128,14 +128,10 @@ pub fn update_job_application<C: Queryable>(
     }
 
     // End with the WHERE clause
-    query_builder += "\nWHERE id = :id
-    RETURNING id, source, company, job_title, application_date, time_investment, automated_response, human_response, human_response_date, application_website, notes";
+    query_builder += "\nWHERE id = :id";
+    // RETURNING id, source, company, job_title, application_date, time_investment, automated_response, human_response, human_response_date, application_website, notes";
 
-    conn.exec_first(query_builder, partial_application)?
-        .map(map_row)
-        .ok_or(Box::<dyn std::error::Error>::from(
-            "No job application found",
-        ))
+    conn.exec_drop(query_builder, partial_application).map_err(Box::<dyn std::error::Error>::from)
 }
 
 /// Delete a job application from the database

--- a/src/user_interface/command_line.rs
+++ b/src/user_interface/command_line.rs
@@ -5,7 +5,7 @@ use std::{
     path::Path,
 };
 
-use mysql::{prelude::Queryable, PooledConn};
+use mysql::prelude::Queryable;
 use time::{macros::format_description, Date, Duration};
 
 use crate::repository::{
@@ -348,8 +348,6 @@ fn update_other_command<C: Queryable>(
     conn: &mut C,
     id: i32,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let _ = |c: &mut PooledConn, a| update_job_application(c, a);
-
     // This will be used by multiple inputs
     let wrap_ok = |s: &str| {
         Result::<_, Infallible>::Ok(if s.is_empty() {
@@ -495,8 +493,8 @@ fn update_other_command<C: Queryable>(
         // Add the ID of the job application to modify
         partial_application.0.push(JobApplicationField::Id(id));
         // For confirmation, print the returned job application
-        let new_job_application = update_job_application(conn, partial_application)?;
-        print_job_application_to_terminal(&new_job_application);
+        update_job_application(conn, partial_application)?;
+        // print_job_application_to_terminal(&new_job_application);
 
         Ok(())
     }


### PR DESCRIPTION
Closes #11

- Fixed `automated_response` being stored as 1 or 0 instead of 'Y' or 'N'
- Removed "RETURNING" clause from update_job_application because MySQL does not support it
- Fixed duplicate "SET" clause in update_job_application