### PR TITLE
Make human_response an enum instead of nullable varchar

### DIFF
--- a/setup_scripts/db_config.sql
+++ b/setup_scripts/db_config.sql
@@ -13,7 +13,7 @@ CREATE TABLE job_applications (
     application_date DATE NOT NULL,
     time_investment TIME,
     automated_response CHAR NOT NULL DEFAULT 'N' COMMENT 'Y=true,N=FALSE',
-    human_response VARCHAR(60),
+    human_response ENUM('N','R','I') NOT NULL DEFAULT 'N',
     human_response_date DATE,
     application_website VARCHAR(255),
     notes TEXT


### PR DESCRIPTION
Human response will now be represented in the database as a single-character enum instead of a string. The enum is also not nullable anymore to make the code a little more concise. 'N' = None, 'R' = Rejection, 'I' = Interview request.