### PR TITLE
Implement FromRow for job applications

### DIFF
--- a/src/user_interface/command_line.rs
+++ b/src/user_interface/command_line.rs
@@ -289,12 +289,8 @@ Notes: {}",
                 let duration_between_dates = resp_date - ja.application_date;
                 duration_between_dates.whole_days().to_string()
             }),
-        ja.application_website
-            .as_deref()
-            .unwrap_or(""),
-        ja.notes
-            .as_deref()
-            .unwrap_or(""),
+        ja.application_website.as_deref().unwrap_or_default(),
+        ja.notes.as_deref().unwrap_or_default(),
     );
 }
 
@@ -491,7 +487,7 @@ fn update_other_command<C: Queryable>(
                     notes += "\n";
                     // And keep looking
                     // unwrap_or("") because this `wrap_ok` returns `None` if empty, unlike the version of `wrap_ok` in `create()`
-                    note_line = input("\\`bquote>", wrap_ok)?.unwrap_or("".to_owned());
+                    note_line = input("\\`bquote>", wrap_ok)?.unwrap_or_default();
                 }
             }
             partial_application


### PR DESCRIPTION
Instead of using a `map_row` function in job_application_repository, implement `FromRow` for `JobApplication` and let generics handle conversion. `FromRow` can be defined on structs if all members are `FromValue`.

The only value left that wasn't just using the default `FromValue` implementation in `map_row` was `HumanResponse`. There is a derive macro for the trait, but I don't trust how mysql executes that macro. The source code for the macro is difficult to read. The documentation for the macro is also incorrect. There is a required field attribute that has no documentation, and I couldn't figure out how to use the mysql(with) field attribute (which is in the documentation. This is all on top of the fact that the macro also defines `Into<Value>` for an enum as just its representative integer, which is less stable than going by name.

There were also a little bit of other refactoring. Now all of the functions in job_application_repository just return whatever is returned by the Queryable method, except for `insert_new_job_application`, which returns the given application. I'm not sure why that even returns anything, the Ok value is never used.

closes #8