### PR TITLE
Add some tests

### DIFF
--- a/src/repository/job_application_model.rs
+++ b/src/repository/job_application_model.rs
@@ -11,7 +11,7 @@ use mysql::{
 use time::{Date, Duration};
 
 /// A row in the job application table
-#[derive(Debug, Clone, FromRow)]
+#[derive(Debug, Clone, FromRow, PartialEq, Eq)]
 #[mysql(table_name = "job_applications")]
 pub struct JobApplication {
     pub id: i32,
@@ -43,7 +43,7 @@ impl Into<Params> for &JobApplication {
 }
 
 /// Enum to hold possible human responses
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum HumanResponse {
     #[default]
     None,
@@ -157,5 +157,173 @@ impl Into<Params> for PartialJobApplication {
             params_map.insert(field.name().as_bytes().to_vec(), field.to_value());
         }
         Params::Named(params_map)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use time::{ext::NumericalDuration, Month};
+
+    use super::*;
+
+    /// Test Into<Params> for JobApplication when all fields are non-null
+    #[test]
+    fn test_into_params() {
+        // Example job application
+        let example_job_application = JobApplication {
+            id: 12,
+            source: "foo source".to_owned(),
+            company: "foo company".to_owned(),
+            job_title: "foo job".to_owned(),
+            application_date: Date::from_calendar_date(2001, Month::February, 2).unwrap(),
+            time_investment: Some(90.seconds()),
+            human_response: HumanResponse::Rejection,
+            human_response_date: Some(Date::from_calendar_date(2001, Month::February, 3).unwrap()),
+            application_website: Some("foo website".to_owned()),
+            notes: Some("foo notes".to_owned()),
+        };
+
+        // Convert using impl Into<Params> for &JobApplication
+        let actual_params: Params = (&example_job_application).into();
+        let expected_map = HashMap::from([
+            // Into<Params> never applies id because MySQL auto increment handles that
+            // (b"id".to_vec(), Value::Int(12)),
+            (b"source".to_vec(), Value::Bytes(b"foo source".to_vec())),
+            (b"company".to_vec(), Value::Bytes(b"foo company".to_vec())),
+            (b"job_title".to_vec(), Value::Bytes(b"foo job".to_vec())),
+            (
+                b"application_date".to_vec(),
+                Value::Date(2001, 2, 2, 0, 0, 0, 0),
+            ),
+            (
+                b"time_investment".to_vec(),
+                Value::Time(false, 0, 0, 1, 30, 0),
+            ),
+            (b"human_response".to_vec(), Value::Bytes(b"R".to_vec())),
+            (
+                b"human_response_date".to_vec(),
+                Value::Date(2001, 2, 3, 0, 0, 0, 0),
+            ),
+            (
+                b"application_website".to_vec(),
+                Value::Bytes(b"foo website".to_vec()),
+            ),
+            (b"notes".to_vec(), Value::Bytes(b"foo notes".to_vec())),
+        ]);
+
+        // Ensure the params are named
+        if let Params::Named(actual_map) = actual_params {
+            // Assert there are 10 parameters so
+            assert_eq!(
+                actual_map, expected_map,
+                "Actual and expected params differ"
+            );
+        } else {
+            panic!(
+                "params should be positional, actual params is {:?}",
+                actual_params
+            );
+        }
+    }
+
+    /// Test Into<Params> for JobApplication when all nullable fields are nullable
+    #[test]
+    fn test_into_params_null() {
+        // Example job application
+        let example_job_application = JobApplication {
+            id: 12,
+            source: "foo source".to_owned(),
+            company: "foo company".to_owned(),
+            job_title: "foo job".to_owned(),
+            application_date: Date::from_calendar_date(2001, Month::February, 2).unwrap(),
+            time_investment: None,
+            human_response: HumanResponse::None,
+            human_response_date: None,
+            application_website: None,
+            notes: None,
+        };
+
+        // Convert using impl Into<Params> for &JobApplication
+        let actual_params: Params = (&example_job_application).into();
+        let expected_map = HashMap::from([
+            // Into<Params> never applies id because MySQL auto increment handles that
+            // (b"id".to_vec(), Value::Int(12)),
+            (b"source".to_vec(), Value::Bytes(b"foo source".to_vec())),
+            (b"company".to_vec(), Value::Bytes(b"foo company".to_vec())),
+            (b"job_title".to_vec(), Value::Bytes(b"foo job".to_vec())),
+            (
+                b"application_date".to_vec(),
+                Value::Date(2001, 2, 2, 0, 0, 0, 0),
+            ),
+            (b"time_investment".to_vec(), Value::NULL),
+            (b"human_response".to_vec(), Value::Bytes(b"N".to_vec())),
+            (b"human_response_date".to_vec(), Value::NULL),
+            (b"application_website".to_vec(), Value::NULL),
+            (b"notes".to_vec(), Value::NULL),
+        ]);
+
+        // Ensure the params are named
+        if let Params::Named(actual_map) = actual_params {
+            // Assert there are 10 parameters so
+            assert_eq!(
+                actual_map, expected_map,
+                "Actual and expected params differ"
+            );
+        } else {
+            panic!(
+                "params should be positional, actual params is {:?}",
+                actual_params
+            );
+        }
+    }
+
+    /// Test ToValue for HumanResponse
+    #[test]
+    fn test_to_value_human_response() {
+        assert_eq!(
+            HumanResponse::None.to_value(),
+            Value::Bytes(b"N".to_vec()),
+            "None -> N"
+        );
+        assert_eq!(
+            HumanResponse::Rejection.to_value(),
+            Value::Bytes(b"R".to_vec()),
+            "Rejection -> R"
+        );
+        assert_eq!(
+            HumanResponse::InterviewRequest.to_value(),
+            Value::Bytes(b"I".to_vec()),
+            "InterviewRequest -> I"
+        );
+    }
+
+    // FromRow can't really be tested because `Row` fields are all private.
+
+    // Test all possible values to HumanResponse
+    #[test]
+    fn test_from_value_human_response() {
+        // Normal cases
+        assert_eq!(
+            HumanResponse::from_value(Value::Bytes(b"N".to_vec())),
+            HumanResponse::None,
+            "N -> None"
+        );
+        assert_eq!(
+            HumanResponse::from_value(Value::Bytes(b"R".to_vec())),
+            HumanResponse::Rejection,
+            "R -> Rejection"
+        );
+        assert_eq!(
+            HumanResponse::from_value(Value::Bytes(b"I".to_vec())),
+            HumanResponse::InterviewRequest,
+            "I -> InterviewRequest"
+        );
+
+        // Error case: using "" instead of NULL because intermediate String cannot be constructed from NULL
+        assert_eq!(
+            HumanResponse::from_value(Value::Bytes(b"".to_vec())),
+            HumanResponse::None,
+            "Unknown value -> None"
+        );
     }
 }

--- a/src/repository/job_application_model.rs
+++ b/src/repository/job_application_model.rs
@@ -326,4 +326,66 @@ mod tests {
             "Unknown value -> None"
         );
     }
+
+    /// Test Into<Params> for PartialJobApplication
+    #[test]
+    fn test_into_params_partial() {
+        // This should be the same job application as test_into_params, but as a PartialJobApplication
+        let example_job_application: PartialJobApplication = PartialJobApplication(vec![
+            JobApplicationField::Source("foo source".to_owned()),
+            JobApplicationField::Company("foo company".to_owned()),
+            JobApplicationField::JobTitle("foo job".to_owned()),
+            JobApplicationField::ApplicationDate(
+                Date::from_calendar_date(2001, Month::February, 2).unwrap(),
+            ),
+            JobApplicationField::TimeInvestment(Some(90.seconds())),
+            JobApplicationField::HumanResponse(HumanResponse::Rejection),
+            JobApplicationField::HumanResponseDate(Some(
+                Date::from_calendar_date(2001, Month::February, 3).unwrap(),
+            )),
+            JobApplicationField::ApplicationWebsite(Some("foo website".to_owned())),
+            JobApplicationField::Notes(Some("foo notes".to_owned())),
+        ]);
+
+        // This is all the same as test_into_params
+        // Convert using impl Into<Params> for PartialJobApplication
+        let actual_params: Params = example_job_application.into();
+        let expected_map = HashMap::from([
+            (b"source".to_vec(), Value::Bytes(b"foo source".to_vec())),
+            (b"company".to_vec(), Value::Bytes(b"foo company".to_vec())),
+            (b"job_title".to_vec(), Value::Bytes(b"foo job".to_vec())),
+            (
+                b"application_date".to_vec(),
+                Value::Date(2001, 2, 2, 0, 0, 0, 0),
+            ),
+            (
+                b"time_investment".to_vec(),
+                Value::Time(false, 0, 0, 1, 30, 0),
+            ),
+            (b"human_response".to_vec(), Value::Bytes(b"R".to_vec())),
+            (
+                b"human_response_date".to_vec(),
+                Value::Date(2001, 2, 3, 0, 0, 0, 0),
+            ),
+            (
+                b"application_website".to_vec(),
+                Value::Bytes(b"foo website".to_vec()),
+            ),
+            (b"notes".to_vec(), Value::Bytes(b"foo notes".to_vec())),
+        ]);
+
+        // Ensure the params are named
+        if let Params::Named(actual_map) = actual_params {
+            // Assert there are 10 parameters so
+            assert_eq!(
+                actual_map, expected_map,
+                "Actual and expected params differ"
+            );
+        } else {
+            panic!(
+                "params should be positional, actual params is {:?}",
+                actual_params
+            );
+        }
+    }
 }

--- a/src/user_interface/command_line.rs
+++ b/src/user_interface/command_line.rs
@@ -458,7 +458,7 @@ fn update_other_command<C: Queryable>(
     );
 
     // Not using the macro for this one because it can be multiline and nothing else should behave anything like this
-    let first_notes_line = input("Notes\nLeave blank to leave unchanged: ", |s: &str| {
+    let first_notes_line = input("Notes\nLeave blank to leave unchanged:", |s: &str| {
         if s == "remove" {
             Ok(Some(None))
         } else {


### PR DESCRIPTION
## Tested:

- `Into<Params>` for `JobApplication`
- `ToValue` and `FromValue` for `HumanResponse`
- `Into<Params>` for `PartialJobApplication`

## Not tested:

- `FromRow` for `HumanResponse`: I couldn't find a way to generate a `Row` object. All fields and constructors are private.
- The CLI: The easiest way to test this would involve spoofing the repository (which can be accomplished with cfg directives) and passing around trait objects instead of just making all the functions get `stdin` and `stdout` from the standard functions and macros. This can be done, but would make the fairly simple functions much harder to read.
- The repository actions not mentioned above: I thought I could easily create a mock `Queryable` for the functions, since they all use the generic trait, but it seems to either be hard or impossible to implement the generic functions with more specific ones.

I may revisit this branch and issue later, but for now this is all that's being done.