### PR TITLE
24 add support for sqlite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["cli", "gui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/stdonnelly/ats-tracking-system"

--- a/README.md
+++ b/README.md
@@ -25,15 +25,22 @@ Both are standalone executables that can be moved used anywhere, but they will b
 #### MySQL
 
 Using the argument `--features repository/mysql` when compiling will cause the application to use MySQL instead of SQLite for the database.
-This means that the `ats-tracking.db3` file will not be used, but a connection to a MySQL server will be required. Additionally, both executables will require a file named `.env` in the same directory or a parent directory as the executable. The .env file should define the following environment variables:
+This means that the `ats-tracking.db3` file will not be used, but a connection to a MySQL server will be required.
+The connection must be to a database that contains the `job_applications` table, and a user that has DELETE, INSERT, SELECT, and UPDATE permissions to that table.
+The schema for that table is in [db_config.sql](setup_scripts/db_config.sql).
 
-- DB_DATABASE
-- DB_USER
-- DB_PASSWORD
-- DB_HOST
-- DB_PORT
+The following environment variables are used by the MySQL version of the ATS tracking system.
+They can either be defined as environment variables, or in a file named ".env" in the same folder as the executable (or a parent folder).
 
-Additionally, they expect the user given by `DB_USER` to have read/write access to a table named `job_applications`, who's schema is defined in [db_config.sql](setup_scripts/db_config.sql).
+- DB_DATABASE: The name of the database to be used by ats-tracking
+- DB_USER: The username for ats-tracking to use for database access
+- DB_PASSWORD: The password for ats-tracking to use for database access
+- DB_HOST: Optional - The hostname or IP address of the database. Defaults to `127.0.0.1`
+- DB_PORT: Optional - The port of the database. Defaults to `3306`
+
+#### Optimization
+
+The `--release` argument is not necessary. It just makes the compiled application run a bit faster. See [Profiles - The Cargo Book](https://doc.rust-lang.org/cargo/reference/profiles.html) for more information.
 
 #### Only compiling one executable
 
@@ -74,7 +81,7 @@ This was the first interface that was made. It can still be used with the execut
 There is now (as of version 0.2.0) a graphical interface, with the executable`ats-tracking`.
 This uses [Slint](https://slint.dev/).
 Currently, there are some features present in the CLI version, but not the GUI version.
-Some of these features are irrelevant to the GUI (i.e. a partial update is unnecessar because the app can just pre-fill the form).
+Some of these features are irrelevant to the GUI (i.e. a partial update is unnecessary because the app can just pre-fill the form).
 
 ## License
 
@@ -83,4 +90,4 @@ Any derivatives of this project that include Slint need to use one of the [Slint
 
 ## Footnotes
 
-[^1]: Because the function that finds the home directory is not implemented correctly for Rust <= 1.84, the `ats-tracking.db3` may be placed in the wrong directory on Windows, or the application may fail to run. macOS, Linux, and other Unix-like operating systems are unaffected.
+[^1]: Because the function that finds the home directory is not implemented correctly for Rust <= 1.84, the `ats-tracking.db3` may be placed in the wrong directory on Windows, or the application may fail to run. macOS, Linux, and other Unix-like operating systems are unaffected. See the deprecation notice on [home_dir](https://doc.rust-lang.org/1.84.0/std/env/fn.home_dir.html#deprecation)

--- a/README.md
+++ b/README.md
@@ -10,20 +10,77 @@ This was created because, at the time of writing, landing a software development
 Because most employers receive numerous applications, many elect to use applicant tracking systems \[ATS\]s
 Many applications do not even receive a response, making this a useful tool for determining where to send follow-ups, assuming the applicant is willing to follow up.
 
+## Building
+
+The Rust compiler is required. See [Install Rust](https://www.rust-lang.org/tools/install).
+
+For the default options, with optimizations: Run `cargo build --release` in this repository's root directory. In case you aren't used to the Rust compiler, this will take a few minutes.
+
+This will create two executables in the `target/release/` folder: `ats-tracking` and `ats-tracking-cli`.
+These are the executables the GUI and CLI versions respectively.
+Both are standalone executables that can be moved used anywhere, but they will both create and use a file named `ats-tracking.db3` in the user's home directory (`$HOME` on macOS/Linux/Unix-like, or `%USERPROFILE%` on Windows[^1]).
+
+### Options
+
+#### MySQL
+
+Using the argument `--features repository/mysql` when compiling will cause the application to use MySQL instead of SQLite for the database.
+This means that the `ats-tracking.db3` file will not be used, but a connection to a MySQL server will be required. Additionally, both executables will require a file named `.env` in the same directory or a parent directory as the executable. The .env file should define the following environment variables:
+
+- DB_DATABASE
+- DB_USER
+- DB_PASSWORD
+- DB_HOST
+- DB_PORT
+
+Additionally, they expect the user given by `DB_USER` to have read/write access to a table named `job_applications`, who's schema is defined in [db_config.sql](setup_scripts/db_config.sql).
+
+#### Only compiling one executable
+
+It is possible to only build one of the executables by building with `--bin ats-tracking` or `--bin ats-tracking-cli` to select which binary to compile.
+
 ## Basic architecture
 
-- Programming language: Rust.
-  While it is not the most appropriate language for this project, I decided to use Rust for the majority of the code.
-  This is mainly for me to become more familiar with the language.
-- Database: MySQL or MariaDB.
-  MariaDB is simple to install on Linux and set up.
-  All data this project will likely involve easily fits into ordinary SQL tables.
-  At the time of writing this, the only data that needs to be stored is whatever is related to each job application and maybe login information if this becomes a webapp.
-- Frontend: During initial development and testing, there will be a command-line interface.
-  After most of the application is developed, some kind of GUI will probably be made.
-  This may be either GTK, Qt, or some web frontend.
+### Programming language
+
+Rust
+
+While it is not the most appropriate language for this project, I decided to use Rust for the majority of the code.
+This is mainly for me to become more familiar with the language.
+
+### Database
+
+#### SQLite
+
+This is the new default as of version 0.3.0.
+MySQL is still available using the feature `repository/mysql`.
+This has been added because this application does not need an actual SQL server, which add complexity in deployment.
+ As an added benefit, SQLite is easier to test because I can create in-memory SQLite databases.
+
+#### MySQL or MariaDB
+
+MariaDB is simple to install on Linux and set up.
+All data this project will likely involve easily fits into ordinary SQL tables.
+At the time of writing this, the only data that needs to be stored is whatever is related t each job application and maybe login information if this becomes a webapp.
+
+### Frontend
+
+#### CLI
+
+This was the first interface that was made. It can still be used with the executable`ats-tracking-cli`.
+
+#### GUI
+
+There is now (as of version 0.2.0) a graphical interface, with the executable`ats-tracking`.
+This uses [Slint](https://slint.dev/).
+Currently, there are some features present in the CLI version, but not the GUI version.
+Some of these features are irrelevant to the GUI (i.e. a partial update is unnecessar because the app can just pre-fill the form).
 
 ## License
 
 This software is licensed under the MIT license (see [LICENSE](LICENSE)) but uses the Slint library under the GNU GPLv3 license for the gui crate.
 Any derivatives of this project that include Slint need to use one of the [Slint licenses](https://github.com/slint-ui/slint/blob/master/LICENSE.md).
+
+## Footnotes
+
+[^1]: Because the function that finds the home directory is not implemented correctly for Rust <= 1.84, the `ats-tracking.db3` may be placed in the wrong directory on Windows, or the application may fail to run. macOS, Linux, and other Unix-like operating systems are unaffected.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,7 +7,8 @@ mod shell_option;
 
 fn main() {
     // Objects that should be owned by the main function
-    dotenv().unwrap();
+    // We don't really care is a .env file is successfully found because we can just use actual environment variables
+    _ = dotenv();
     let mut conn = repository::get_conn().unwrap();
 
     command_line::main_loop(&mut conn).unwrap();

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -20,7 +20,8 @@ mod controller;
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Objects that should be owned by the main function
-    dotenv()?;
+    // We don't really care is a .env file is successfully found because we can just use actual environment variables
+    _ = dotenv();
     let conn = Rc::new(RefCell::new(repository::get_conn()?));
     let ui = AppWindow::new()?;
 

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -1,11 +1,11 @@
 //! Entry point for the GUI version of ats-tracking
-//! 
+//!
 //! This crate uses Slint for a GUI.
 
 // Some workaround for windows that was in the project template
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use std::{cell::RefCell, error::Error, rc::Rc};
+use std::{cell::RefCell, error::Error, ops::DerefMut, rc::Rc};
 
 use controller::{
     handle_date_diff, handle_new_job_application, handle_submit_job_application,
@@ -25,7 +25,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let ui = AppWindow::new()?;
 
     // Set initial state
-    init_ui(RefCell::borrow_mut(&conn).as_mut(), &ui);
+    init_ui(RefCell::borrow_mut(&conn).deref_mut(), &ui);
 
     // Set up callbacks
     handle_use_job_application(&conn, &ui);

--- a/repository/Cargo.toml
+++ b/repository/Cargo.toml
@@ -5,6 +5,13 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+mysql = ["dep:mysql"]
+
 [dependencies]
-mysql = "25.0.1"
+mysql = { version = "25.0.1", optional = true }
 time = { version = "0.3.36", features = ["default", "local-offset", "macros", "parsing"] }
+rusqlite = { version = "0.32.1", features = ["bundled"] }
+
+[dev-dependencies]
+tempfile = "3.15.0"

--- a/repository/Cargo.toml
+++ b/repository/Cargo.toml
@@ -11,7 +11,7 @@ mysql = ["dep:mysql"]
 [dependencies]
 mysql = { version = "25.0.1", optional = true }
 time = { version = "0.3.36", features = ["default", "local-offset", "macros", "parsing"] }
-rusqlite = { version = "0.32.1", features = ["bundled"] }
+rusqlite = { version = "0.32.1", features = ["bundled", "time"] }
 
 [dev-dependencies]
 tempfile = "3.15.0"

--- a/repository/src/job_application_model.rs
+++ b/repository/src/job_application_model.rs
@@ -1,14 +1,17 @@
 use std::fmt::{Debug, Display};
 
-#[cfg(feature = "mysql")]
-use mysql::{
-    params,
-    prelude::{FromRow, FromValue, ToValue},
-    Params, Value,
-};
-#[cfg(feature = "mysql")]
-use std::collections::HashMap;
 use time::{Date, Duration};
+
+#[cfg(feature = "mysql")]
+use mysql::prelude::FromRow;
+
+/// Implementation using a mysql backend
+#[cfg(feature = "mysql")]
+mod mysql_backend;
+
+/// Implementation with an sqlite backend
+#[cfg(not(feature = "mysql"))]
+mod sqlite_backend;
 
 /// A row in the job application table
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -35,24 +38,6 @@ pub struct JobApplication {
     pub application_website: Option<String>,
     /// Notes on anything notable about the application process or company
     pub notes: Option<String>,
-}
-
-#[cfg(feature = "mysql")]
-impl Into<Params> for &JobApplication {
-    fn into(self) -> Params {
-        params! {
-            "id" => &self.id,
-            "source" => &self.source,
-            "company" => &self.company,
-            "job_title" => &self.job_title,
-            "application_date" => &self.application_date,
-            "time_investment" => &self.time_investment,
-            "human_response" => &self.human_response,
-            "human_response_date" => &self.human_response_date,
-            "application_website" => &self.application_website,
-            "notes" => &self.notes,
-        }
-    }
 }
 
 /// Enum to hold possible human responses
@@ -97,25 +82,6 @@ impl From<String> for HumanResponse {
     }
 }
 
-#[cfg(feature = "mysql")]
-impl ToValue for HumanResponse {
-    fn to_value(&self) -> Value {
-        match self {
-            HumanResponse::None => "N",
-            HumanResponse::Rejection => "R",
-            HumanResponse::InterviewRequest => "I",
-        }
-        .to_value()
-    }
-}
-
-#[cfg(feature = "mysql")]
-impl FromValue for HumanResponse {
-    // All we need to do is specify an intermediate.
-    // The default implementation automatically converts `Value` -> `String` -> `HumanResponse`
-    type Intermediate = String;
-}
-
 /// Field in a JobApplication to allow the creation of partial job applications
 pub enum JobApplicationField {
     /// The table primary key
@@ -158,264 +124,5 @@ impl JobApplicationField {
     }
 }
 
-#[cfg(feature = "mysql")]
-impl ToValue for JobApplicationField {
-    fn to_value(&self) -> Value {
-        match self {
-            JobApplicationField::Id(o) => o.to_value(),
-            JobApplicationField::Source(o) => o.to_value(),
-            JobApplicationField::Company(o) => o.to_value(),
-            JobApplicationField::JobTitle(o) => o.to_value(),
-            JobApplicationField::ApplicationDate(o) => o.to_value(),
-            JobApplicationField::TimeInvestment(o) => o.to_value(),
-            JobApplicationField::HumanResponse(o) => o.to_value(),
-            JobApplicationField::HumanResponseDate(o) => o.to_value(),
-            JobApplicationField::ApplicationWebsite(o) => o.to_value(),
-            JobApplicationField::Notes(o) => o.to_value(),
-        }
-    }
-}
-
 /// Newtype to allow impl Into<Params>
 pub struct PartialJobApplication(pub Vec<JobApplicationField>);
-
-#[cfg(feature = "mysql")]
-impl Into<Params> for PartialJobApplication {
-    fn into(self) -> Params {
-        let mut params_map: HashMap<Vec<u8>, Value> = HashMap::with_capacity(self.0.len());
-        for field in self.0 {
-            params_map.insert(field.name().as_bytes().to_vec(), field.to_value());
-        }
-        Params::Named(params_map)
-    }
-}
-
-#[cfg(all(test, feature = "mysql"))]
-mod tests {
-    use time::{ext::NumericalDuration, Month};
-
-    use super::*;
-
-    /// Test Into<Params> for JobApplication when all fields are non-null
-    #[test]
-    fn test_into_params() {
-        // Example job application
-        let example_job_application = JobApplication {
-            id: 12,
-            source: "foo source".to_owned(),
-            company: "foo company".to_owned(),
-            job_title: "foo job".to_owned(),
-            application_date: Date::from_calendar_date(2001, Month::February, 2).unwrap(),
-            time_investment: Some(90.seconds()),
-            human_response: HumanResponse::Rejection,
-            human_response_date: Some(Date::from_calendar_date(2001, Month::February, 3).unwrap()),
-            application_website: Some("foo website".to_owned()),
-            notes: Some("foo notes".to_owned()),
-        };
-
-        // Convert using impl Into<Params> for &JobApplication
-        let actual_params: Params = (&example_job_application).into();
-        let expected_map = HashMap::from([
-            // Into<Params> never applies id because MySQL auto increment handles that
-            // (b"id".to_vec(), Value::Int(12)),
-            (b"source".to_vec(), Value::Bytes(b"foo source".to_vec())),
-            (b"company".to_vec(), Value::Bytes(b"foo company".to_vec())),
-            (b"job_title".to_vec(), Value::Bytes(b"foo job".to_vec())),
-            (
-                b"application_date".to_vec(),
-                Value::Date(2001, 2, 2, 0, 0, 0, 0),
-            ),
-            (
-                b"time_investment".to_vec(),
-                Value::Time(false, 0, 0, 1, 30, 0),
-            ),
-            (b"human_response".to_vec(), Value::Bytes(b"R".to_vec())),
-            (
-                b"human_response_date".to_vec(),
-                Value::Date(2001, 2, 3, 0, 0, 0, 0),
-            ),
-            (
-                b"application_website".to_vec(),
-                Value::Bytes(b"foo website".to_vec()),
-            ),
-            (b"notes".to_vec(), Value::Bytes(b"foo notes".to_vec())),
-        ]);
-
-        // Ensure the params are named
-        if let Params::Named(actual_map) = actual_params {
-            // Assert there are 10 parameters so
-            assert_eq!(
-                actual_map, expected_map,
-                "Actual and expected params differ"
-            );
-        } else {
-            panic!(
-                "params should be positional, actual params is {:?}",
-                actual_params
-            );
-        }
-    }
-
-    /// Test Into<Params> for JobApplication when all nullable fields are nullable
-    #[test]
-    fn test_into_params_null() {
-        // Example job application
-        let example_job_application = JobApplication {
-            id: 12,
-            source: "foo source".to_owned(),
-            company: "foo company".to_owned(),
-            job_title: "foo job".to_owned(),
-            application_date: Date::from_calendar_date(2001, Month::February, 2).unwrap(),
-            time_investment: None,
-            human_response: HumanResponse::None,
-            human_response_date: None,
-            application_website: None,
-            notes: None,
-        };
-
-        // Convert using impl Into<Params> for &JobApplication
-        let actual_params: Params = (&example_job_application).into();
-        let expected_map = HashMap::from([
-            // Into<Params> never applies id because MySQL auto increment handles that
-            // (b"id".to_vec(), Value::Int(12)),
-            (b"source".to_vec(), Value::Bytes(b"foo source".to_vec())),
-            (b"company".to_vec(), Value::Bytes(b"foo company".to_vec())),
-            (b"job_title".to_vec(), Value::Bytes(b"foo job".to_vec())),
-            (
-                b"application_date".to_vec(),
-                Value::Date(2001, 2, 2, 0, 0, 0, 0),
-            ),
-            (b"time_investment".to_vec(), Value::NULL),
-            (b"human_response".to_vec(), Value::Bytes(b"N".to_vec())),
-            (b"human_response_date".to_vec(), Value::NULL),
-            (b"application_website".to_vec(), Value::NULL),
-            (b"notes".to_vec(), Value::NULL),
-        ]);
-
-        // Ensure the params are named
-        if let Params::Named(actual_map) = actual_params {
-            // Assert there are 10 parameters so
-            assert_eq!(
-                actual_map, expected_map,
-                "Actual and expected params differ"
-            );
-        } else {
-            panic!(
-                "params should be positional, actual params is {:?}",
-                actual_params
-            );
-        }
-    }
-
-    /// Test ToValue for HumanResponse
-    #[test]
-    fn test_to_value_human_response() {
-        assert_eq!(
-            HumanResponse::None.to_value(),
-            Value::Bytes(b"N".to_vec()),
-            "None -> N"
-        );
-        assert_eq!(
-            HumanResponse::Rejection.to_value(),
-            Value::Bytes(b"R".to_vec()),
-            "Rejection -> R"
-        );
-        assert_eq!(
-            HumanResponse::InterviewRequest.to_value(),
-            Value::Bytes(b"I".to_vec()),
-            "InterviewRequest -> I"
-        );
-    }
-
-    // FromRow can't really be tested because `Row` fields are all private.
-
-    // Test all possible values to HumanResponse
-    #[test]
-    fn test_from_value_human_response() {
-        // Normal cases
-        assert_eq!(
-            HumanResponse::from_value(Value::Bytes(b"N".to_vec())),
-            HumanResponse::None,
-            "N -> None"
-        );
-        assert_eq!(
-            HumanResponse::from_value(Value::Bytes(b"R".to_vec())),
-            HumanResponse::Rejection,
-            "R -> Rejection"
-        );
-        assert_eq!(
-            HumanResponse::from_value(Value::Bytes(b"I".to_vec())),
-            HumanResponse::InterviewRequest,
-            "I -> InterviewRequest"
-        );
-
-        // Error case: using "" instead of NULL because intermediate String cannot be constructed from NULL
-        assert_eq!(
-            HumanResponse::from_value(Value::Bytes(b"".to_vec())),
-            HumanResponse::None,
-            "Unknown value -> None"
-        );
-    }
-
-    /// Test Into<Params> for PartialJobApplication
-    #[test]
-    fn test_into_params_partial() {
-        // This should be the same job application as test_into_params, but as a PartialJobApplication
-        let example_job_application: PartialJobApplication = PartialJobApplication(vec![
-            JobApplicationField::Source("foo source".to_owned()),
-            JobApplicationField::Company("foo company".to_owned()),
-            JobApplicationField::JobTitle("foo job".to_owned()),
-            JobApplicationField::ApplicationDate(
-                Date::from_calendar_date(2001, Month::February, 2).unwrap(),
-            ),
-            JobApplicationField::TimeInvestment(Some(90.seconds())),
-            JobApplicationField::HumanResponse(HumanResponse::Rejection),
-            JobApplicationField::HumanResponseDate(Some(
-                Date::from_calendar_date(2001, Month::February, 3).unwrap(),
-            )),
-            JobApplicationField::ApplicationWebsite(Some("foo website".to_owned())),
-            JobApplicationField::Notes(Some("foo notes".to_owned())),
-        ]);
-
-        // This is all the same as test_into_params
-        // Convert using impl Into<Params> for PartialJobApplication
-        let actual_params: Params = example_job_application.into();
-        let expected_map = HashMap::from([
-            (b"source".to_vec(), Value::Bytes(b"foo source".to_vec())),
-            (b"company".to_vec(), Value::Bytes(b"foo company".to_vec())),
-            (b"job_title".to_vec(), Value::Bytes(b"foo job".to_vec())),
-            (
-                b"application_date".to_vec(),
-                Value::Date(2001, 2, 2, 0, 0, 0, 0),
-            ),
-            (
-                b"time_investment".to_vec(),
-                Value::Time(false, 0, 0, 1, 30, 0),
-            ),
-            (b"human_response".to_vec(), Value::Bytes(b"R".to_vec())),
-            (
-                b"human_response_date".to_vec(),
-                Value::Date(2001, 2, 3, 0, 0, 0, 0),
-            ),
-            (
-                b"application_website".to_vec(),
-                Value::Bytes(b"foo website".to_vec()),
-            ),
-            (b"notes".to_vec(), Value::Bytes(b"foo notes".to_vec())),
-        ]);
-
-        // Ensure the params are named
-        if let Params::Named(actual_map) = actual_params {
-            // Assert there are 10 parameters so
-            assert_eq!(
-                actual_map, expected_map,
-                "Actual and expected params differ"
-            );
-        } else {
-            panic!(
-                "params should be positional, actual params is {:?}",
-                actual_params
-            );
-        }
-    }
-}

--- a/repository/src/job_application_model.rs
+++ b/repository/src/job_application_model.rs
@@ -1,18 +1,19 @@
-use std::{
-    collections::HashMap,
-    fmt::{Debug, Display},
-};
+use std::fmt::{Debug, Display};
 
+#[cfg(feature = "mysql")]
 use mysql::{
     params,
     prelude::{FromRow, FromValue, ToValue},
     Params, Value,
 };
+#[cfg(feature = "mysql")]
+use std::collections::HashMap;
 use time::{Date, Duration};
 
 /// A row in the job application table
-#[derive(Debug, Clone, FromRow, PartialEq, Eq)]
-#[mysql(table_name = "job_applications")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "mysql", derive(FromRow))]
+#[cfg_attr(feature = "mysql", mysql(table_name = "job_applications"))]
 pub struct JobApplication {
     /// The table primary key
     pub id: i32,
@@ -36,6 +37,7 @@ pub struct JobApplication {
     pub notes: Option<String>,
 }
 
+#[cfg(feature = "mysql")]
 impl Into<Params> for &JobApplication {
     fn into(self) -> Params {
         params! {
@@ -95,6 +97,7 @@ impl From<String> for HumanResponse {
     }
 }
 
+#[cfg(feature = "mysql")]
 impl ToValue for HumanResponse {
     fn to_value(&self) -> Value {
         match self {
@@ -106,6 +109,7 @@ impl ToValue for HumanResponse {
     }
 }
 
+#[cfg(feature = "mysql")]
 impl FromValue for HumanResponse {
     // All we need to do is specify an intermediate.
     // The default implementation automatically converts `Value` -> `String` -> `HumanResponse`
@@ -154,6 +158,7 @@ impl JobApplicationField {
     }
 }
 
+#[cfg(feature = "mysql")]
 impl ToValue for JobApplicationField {
     fn to_value(&self) -> Value {
         match self {
@@ -174,6 +179,7 @@ impl ToValue for JobApplicationField {
 /// Newtype to allow impl Into<Params>
 pub struct PartialJobApplication(pub Vec<JobApplicationField>);
 
+#[cfg(feature = "mysql")]
 impl Into<Params> for PartialJobApplication {
     fn into(self) -> Params {
         let mut params_map: HashMap<Vec<u8>, Value> = HashMap::with_capacity(self.0.len());
@@ -184,7 +190,7 @@ impl Into<Params> for PartialJobApplication {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "mysql"))]
 mod tests {
     use time::{ext::NumericalDuration, Month};
 

--- a/repository/src/job_application_model/mysql_backend.rs
+++ b/repository/src/job_application_model/mysql_backend.rs
@@ -1,4 +1,6 @@
-use crate::job_application_model::{HumanResponse, JobApplication, JobApplicationField, PartialJobApplication};
+use crate::job_application_model::{
+    HumanResponse, JobApplication, JobApplicationField, PartialJobApplication,
+};
 
 use mysql::{
     params,
@@ -71,7 +73,7 @@ impl Into<Params> for PartialJobApplication {
 
 #[cfg(test)]
 mod tests {
-    use time::{ext::NumericalDuration, Month};
+    use time::{ext::NumericalDuration, Date, Month};
 
     use super::*;
 
@@ -96,7 +98,8 @@ mod tests {
         let actual_params: Params = (&example_job_application).into();
         let expected_map = HashMap::from([
             // Into<Params> never applies id because MySQL auto increment handles that
-            // (b"id".to_vec(), Value::Int(12)),
+            // It still is converted because of the full `update_job_application`
+            (b"id".to_vec(), Value::Int(12)),
             (b"source".to_vec(), Value::Bytes(b"foo source".to_vec())),
             (b"company".to_vec(), Value::Bytes(b"foo company".to_vec())),
             (b"job_title".to_vec(), Value::Bytes(b"foo job".to_vec())),
@@ -156,7 +159,8 @@ mod tests {
         let actual_params: Params = (&example_job_application).into();
         let expected_map = HashMap::from([
             // Into<Params> never applies id because MySQL auto increment handles that
-            // (b"id".to_vec(), Value::Int(12)),
+            // It still is converted because of the full `update_job_application`
+            (b"id".to_vec(), Value::Int(12)),
             (b"source".to_vec(), Value::Bytes(b"foo source".to_vec())),
             (b"company".to_vec(), Value::Bytes(b"foo company".to_vec())),
             (b"job_title".to_vec(), Value::Bytes(b"foo job".to_vec())),

--- a/repository/src/job_application_model/mysql_backend.rs
+++ b/repository/src/job_application_model/mysql_backend.rs
@@ -2,7 +2,7 @@ use crate::job_application_model::{HumanResponse, JobApplication, JobApplication
 
 use mysql::{
     params,
-    prelude::{FromRow, FromValue, ToValue},
+    prelude::{FromValue, ToValue},
     Params, Value,
 };
 

--- a/repository/src/job_application_model/mysql_backend.rs
+++ b/repository/src/job_application_model/mysql_backend.rs
@@ -1,0 +1,300 @@
+use crate::job_application_model::{HumanResponse, JobApplication, JobApplicationField, PartialJobApplication};
+
+use mysql::{
+    params,
+    prelude::{FromRow, FromValue, ToValue},
+    Params, Value,
+};
+
+use std::collections::HashMap;
+
+impl Into<Params> for &JobApplication {
+    fn into(self) -> Params {
+        params! {
+            "id" => &self.id,
+            "source" => &self.source,
+            "company" => &self.company,
+            "job_title" => &self.job_title,
+            "application_date" => &self.application_date,
+            "time_investment" => &self.time_investment,
+            "human_response" => &self.human_response,
+            "human_response_date" => &self.human_response_date,
+            "application_website" => &self.application_website,
+            "notes" => &self.notes,
+        }
+    }
+}
+
+impl ToValue for HumanResponse {
+    fn to_value(&self) -> Value {
+        match self {
+            HumanResponse::None => "N",
+            HumanResponse::Rejection => "R",
+            HumanResponse::InterviewRequest => "I",
+        }
+        .to_value()
+    }
+}
+
+impl FromValue for HumanResponse {
+    // All we need to do is specify an intermediate.
+    // The default implementation automatically converts `Value` -> `String` -> `HumanResponse`
+    type Intermediate = String;
+}
+
+impl ToValue for JobApplicationField {
+    fn to_value(&self) -> Value {
+        match self {
+            JobApplicationField::Id(o) => o.to_value(),
+            JobApplicationField::Source(o) => o.to_value(),
+            JobApplicationField::Company(o) => o.to_value(),
+            JobApplicationField::JobTitle(o) => o.to_value(),
+            JobApplicationField::ApplicationDate(o) => o.to_value(),
+            JobApplicationField::TimeInvestment(o) => o.to_value(),
+            JobApplicationField::HumanResponse(o) => o.to_value(),
+            JobApplicationField::HumanResponseDate(o) => o.to_value(),
+            JobApplicationField::ApplicationWebsite(o) => o.to_value(),
+            JobApplicationField::Notes(o) => o.to_value(),
+        }
+    }
+}
+
+impl Into<Params> for PartialJobApplication {
+    fn into(self) -> Params {
+        let mut params_map: HashMap<Vec<u8>, Value> = HashMap::with_capacity(self.0.len());
+        for field in self.0 {
+            params_map.insert(field.name().as_bytes().to_vec(), field.to_value());
+        }
+        Params::Named(params_map)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use time::{ext::NumericalDuration, Month};
+
+    use super::*;
+
+    /// Test Into<Params> for JobApplication when all fields are non-null
+    #[test]
+    fn test_into_params() {
+        // Example job application
+        let example_job_application = JobApplication {
+            id: 12,
+            source: "foo source".to_owned(),
+            company: "foo company".to_owned(),
+            job_title: "foo job".to_owned(),
+            application_date: Date::from_calendar_date(2001, Month::February, 2).unwrap(),
+            time_investment: Some(90.seconds()),
+            human_response: HumanResponse::Rejection,
+            human_response_date: Some(Date::from_calendar_date(2001, Month::February, 3).unwrap()),
+            application_website: Some("foo website".to_owned()),
+            notes: Some("foo notes".to_owned()),
+        };
+
+        // Convert using impl Into<Params> for &JobApplication
+        let actual_params: Params = (&example_job_application).into();
+        let expected_map = HashMap::from([
+            // Into<Params> never applies id because MySQL auto increment handles that
+            // (b"id".to_vec(), Value::Int(12)),
+            (b"source".to_vec(), Value::Bytes(b"foo source".to_vec())),
+            (b"company".to_vec(), Value::Bytes(b"foo company".to_vec())),
+            (b"job_title".to_vec(), Value::Bytes(b"foo job".to_vec())),
+            (
+                b"application_date".to_vec(),
+                Value::Date(2001, 2, 2, 0, 0, 0, 0),
+            ),
+            (
+                b"time_investment".to_vec(),
+                Value::Time(false, 0, 0, 1, 30, 0),
+            ),
+            (b"human_response".to_vec(), Value::Bytes(b"R".to_vec())),
+            (
+                b"human_response_date".to_vec(),
+                Value::Date(2001, 2, 3, 0, 0, 0, 0),
+            ),
+            (
+                b"application_website".to_vec(),
+                Value::Bytes(b"foo website".to_vec()),
+            ),
+            (b"notes".to_vec(), Value::Bytes(b"foo notes".to_vec())),
+        ]);
+
+        // Ensure the params are named
+        if let Params::Named(actual_map) = actual_params {
+            // Assert there are 10 parameters so
+            assert_eq!(
+                actual_map, expected_map,
+                "Actual and expected params differ"
+            );
+        } else {
+            panic!(
+                "params should be positional, actual params is {:?}",
+                actual_params
+            );
+        }
+    }
+
+    /// Test Into<Params> for JobApplication when all nullable fields are nullable
+    #[test]
+    fn test_into_params_null() {
+        // Example job application
+        let example_job_application = JobApplication {
+            id: 12,
+            source: "foo source".to_owned(),
+            company: "foo company".to_owned(),
+            job_title: "foo job".to_owned(),
+            application_date: Date::from_calendar_date(2001, Month::February, 2).unwrap(),
+            time_investment: None,
+            human_response: HumanResponse::None,
+            human_response_date: None,
+            application_website: None,
+            notes: None,
+        };
+
+        // Convert using impl Into<Params> for &JobApplication
+        let actual_params: Params = (&example_job_application).into();
+        let expected_map = HashMap::from([
+            // Into<Params> never applies id because MySQL auto increment handles that
+            // (b"id".to_vec(), Value::Int(12)),
+            (b"source".to_vec(), Value::Bytes(b"foo source".to_vec())),
+            (b"company".to_vec(), Value::Bytes(b"foo company".to_vec())),
+            (b"job_title".to_vec(), Value::Bytes(b"foo job".to_vec())),
+            (
+                b"application_date".to_vec(),
+                Value::Date(2001, 2, 2, 0, 0, 0, 0),
+            ),
+            (b"time_investment".to_vec(), Value::NULL),
+            (b"human_response".to_vec(), Value::Bytes(b"N".to_vec())),
+            (b"human_response_date".to_vec(), Value::NULL),
+            (b"application_website".to_vec(), Value::NULL),
+            (b"notes".to_vec(), Value::NULL),
+        ]);
+
+        // Ensure the params are named
+        if let Params::Named(actual_map) = actual_params {
+            // Assert there are 10 parameters so
+            assert_eq!(
+                actual_map, expected_map,
+                "Actual and expected params differ"
+            );
+        } else {
+            panic!(
+                "params should be positional, actual params is {:?}",
+                actual_params
+            );
+        }
+    }
+
+    /// Test ToValue for HumanResponse
+    #[test]
+    fn test_to_value_human_response() {
+        assert_eq!(
+            HumanResponse::None.to_value(),
+            Value::Bytes(b"N".to_vec()),
+            "None -> N"
+        );
+        assert_eq!(
+            HumanResponse::Rejection.to_value(),
+            Value::Bytes(b"R".to_vec()),
+            "Rejection -> R"
+        );
+        assert_eq!(
+            HumanResponse::InterviewRequest.to_value(),
+            Value::Bytes(b"I".to_vec()),
+            "InterviewRequest -> I"
+        );
+    }
+
+    // FromRow can't really be tested because `Row` fields are all private.
+
+    // Test all possible values to HumanResponse
+    #[test]
+    fn test_from_value_human_response() {
+        // Normal cases
+        assert_eq!(
+            HumanResponse::from_value(Value::Bytes(b"N".to_vec())),
+            HumanResponse::None,
+            "N -> None"
+        );
+        assert_eq!(
+            HumanResponse::from_value(Value::Bytes(b"R".to_vec())),
+            HumanResponse::Rejection,
+            "R -> Rejection"
+        );
+        assert_eq!(
+            HumanResponse::from_value(Value::Bytes(b"I".to_vec())),
+            HumanResponse::InterviewRequest,
+            "I -> InterviewRequest"
+        );
+
+        // Error case: using "" instead of NULL because intermediate String cannot be constructed from NULL
+        assert_eq!(
+            HumanResponse::from_value(Value::Bytes(b"".to_vec())),
+            HumanResponse::None,
+            "Unknown value -> None"
+        );
+    }
+
+    /// Test Into<Params> for PartialJobApplication
+    #[test]
+    fn test_into_params_partial() {
+        // This should be the same job application as test_into_params, but as a PartialJobApplication
+        let example_job_application: PartialJobApplication = PartialJobApplication(vec![
+            JobApplicationField::Source("foo source".to_owned()),
+            JobApplicationField::Company("foo company".to_owned()),
+            JobApplicationField::JobTitle("foo job".to_owned()),
+            JobApplicationField::ApplicationDate(
+                Date::from_calendar_date(2001, Month::February, 2).unwrap(),
+            ),
+            JobApplicationField::TimeInvestment(Some(90.seconds())),
+            JobApplicationField::HumanResponse(HumanResponse::Rejection),
+            JobApplicationField::HumanResponseDate(Some(
+                Date::from_calendar_date(2001, Month::February, 3).unwrap(),
+            )),
+            JobApplicationField::ApplicationWebsite(Some("foo website".to_owned())),
+            JobApplicationField::Notes(Some("foo notes".to_owned())),
+        ]);
+
+        // This is all the same as test_into_params
+        // Convert using impl Into<Params> for PartialJobApplication
+        let actual_params: Params = example_job_application.into();
+        let expected_map = HashMap::from([
+            (b"source".to_vec(), Value::Bytes(b"foo source".to_vec())),
+            (b"company".to_vec(), Value::Bytes(b"foo company".to_vec())),
+            (b"job_title".to_vec(), Value::Bytes(b"foo job".to_vec())),
+            (
+                b"application_date".to_vec(),
+                Value::Date(2001, 2, 2, 0, 0, 0, 0),
+            ),
+            (
+                b"time_investment".to_vec(),
+                Value::Time(false, 0, 0, 1, 30, 0),
+            ),
+            (b"human_response".to_vec(), Value::Bytes(b"R".to_vec())),
+            (
+                b"human_response_date".to_vec(),
+                Value::Date(2001, 2, 3, 0, 0, 0, 0),
+            ),
+            (
+                b"application_website".to_vec(),
+                Value::Bytes(b"foo website".to_vec()),
+            ),
+            (b"notes".to_vec(), Value::Bytes(b"foo notes".to_vec())),
+        ]);
+
+        // Ensure the params are named
+        if let Params::Named(actual_map) = actual_params {
+            // Assert there are 10 parameters so
+            assert_eq!(
+                actual_map, expected_map,
+                "Actual and expected params differ"
+            );
+        } else {
+            panic!(
+                "params should be positional, actual params is {:?}",
+                actual_params
+            );
+        }
+    }
+}

--- a/repository/src/job_application_model/sqlite_backend.rs
+++ b/repository/src/job_application_model/sqlite_backend.rs
@@ -1,0 +1,54 @@
+use rusqlite::{
+    types::{FromSql, FromSqlError, ToSqlOutput, ValueRef},
+    Row, ToSql,
+};
+use time::ext::NumericalDuration;
+
+use super::{HumanResponse, JobApplication};
+
+impl TryFrom<&Row<'_>> for JobApplication {
+    type Error = rusqlite::Error;
+
+    fn try_from(value: &Row) -> Result<Self, Self::Error> {
+        Ok(JobApplication {
+            id: value.get("id")?,
+            source: value.get("source")?,
+            company: value.get("company")?,
+            job_title: value.get("job_title")?,
+            application_date: value.get("application_date")?,
+            time_investment: value
+                .get::<&str, Option<i64>>("time_investment")?
+                .map(NumericalDuration::seconds),
+            human_response: value.get("human_response")?,
+            human_response_date: value.get("human_response_date")?,
+            application_website: value.get("application_website")?,
+            notes: value.get("notes")?,
+        })
+    }
+}
+
+impl ToSql for HumanResponse {
+    fn to_sql(&self) -> Result<ToSqlOutput<'_>, rusqlite::Error> {
+        Ok(match self {
+            HumanResponse::None => "N",
+            HumanResponse::Rejection => "R",
+            HumanResponse::InterviewRequest => "I",
+        }
+        .into())
+    }
+}
+
+impl FromSql for HumanResponse {
+    fn column_result(value: ValueRef<'_>) -> Result<Self, FromSqlError> {
+        // Get value as string
+        value.as_str().and_then(|s| {
+            // If the value can be mapped to `HumanResponse`, use that
+            s.try_into().map_err(|_| {
+                // If a failure occurred, give an error with a descriptive error message
+                FromSqlError::Other(
+                    format!("Unable to parse value '{s}' into a human response").into(),
+                )
+            })
+        })
+    }
+}

--- a/repository/src/job_application_repository.rs
+++ b/repository/src/job_application_repository.rs
@@ -1,11 +1,16 @@
 use std::{error::Error, fmt::Display};
 
-use mysql::{params, prelude::Queryable};
 use time::Date;
 
-use super::job_application_model::{
-    HumanResponse, JobApplication, JobApplicationField, PartialJobApplication,
-};
+use super::job_application_model::{HumanResponse, JobApplication, PartialJobApplication};
+
+/// Implementation using a mysql backend
+#[cfg(feature = "mysql")]
+mod mysql_backend;
+
+/// Implementation with an sqlite backend
+#[cfg(not(feature = "mysql"))]
+mod sqlite_backend;
 
 /// Abstract representation of some database connection
 ///
@@ -62,138 +67,4 @@ pub trait JobApplicationRepository {
 
     /// Delete the job application with the specified `id`
     fn delete_job_application(&mut self, id: i32) -> Result<(), Self::Error>;
-}
-
-impl<C> JobApplicationRepository for C
-where
-    C: Queryable,
-{
-    type Error = mysql::Error;
-
-    fn get_job_applications(&mut self) -> Result<Vec<JobApplication>, mysql::Error> {
-        self.query(
-        "SELECT id, source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes
-        FROM job_applications"
-    )
-    }
-
-    fn get_pending_job_applications(&mut self) -> Result<Vec<JobApplication>, mysql::Error> {
-        self.query(
-        "SELECT id, source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes
-        FROM job_applications
-        WHERE human_response = 'N'"
-    )
-    }
-
-    fn get_job_application_by_id(
-        &mut self,
-        id: i32,
-    ) -> Result<Option<JobApplication>, mysql::Error> {
-        self.exec_first(
-        "SELECT id, source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes
-        FROM job_applications
-        WHERE id = ?",
-        (id,),
-    )
-    }
-
-    fn search_job_applications(
-        &mut self,
-        query: &str,
-    ) -> Result<Vec<JobApplication>, mysql::Error> {
-        // Add wildcards to the beginning and end of the query
-        let query_with_wildcards = "%".to_owned() + &query.to_lowercase() + "%";
-        self.exec(
-        "SELECT id, source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes
-        FROM job_applications
-        WHERE LOWER(source) LIKE :query
-        OR LOWER(company) LIKE :query
-        OR LOWER(job_title) LIKE :query",
-        params! {"query" => query_with_wildcards}
-    )
-    }
-
-    fn insert_job_application(
-        &mut self,
-        application: &JobApplication,
-    ) -> Result<JobApplication, mysql::Error> {
-        self.exec_first(
-        "INSERT INTO job_applications (source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes)
-        VALUES (:source, :company, :job_title, :application_date, :time_investment, :human_response, :human_response_date, :application_website, :notes)
-        RETURNING id",
-        application
-    )
-    .map(|new_id| JobApplication {id: new_id.unwrap_or_default(), ..application.clone()})
-    }
-
-    fn update_human_response(
-        &mut self,
-        id: i32,
-        human_response: HumanResponse,
-        human_response_date: Option<Date>,
-    ) -> Result<(), mysql::Error> {
-        self.exec_drop(
-            "UPDATE job_applications
-        SET human_response = :human_response, human_response_date = :human_response_date
-        WHERE id = :id",
-            params! {
-                "id" => id,
-                "human_response" => &human_response,
-                "human_response_date" => human_response_date
-            },
-        )
-    }
-
-    fn update_job_application(&mut self, application: &JobApplication) -> Result<(), mysql::Error> {
-        self.exec_drop(
-            "UPDATE job_applications
-        SET source = :source,
-        company = :company,
-        job_title = :job_title,
-        application_date = :application_date,
-        time_investment = :time_investment,
-        human_response = :human_response,
-        human_response_date = :human_response_date,
-        application_website = :application_website,
-        notes = :notes
-        WHERE id = :id",
-            application,
-        )
-    }
-
-    fn update_job_application_partial(
-        &mut self,
-        partial_application: PartialJobApplication,
-    ) -> Result<(), mysql::Error> {
-        let mut query_builder = "UPDATE job_applications".to_owned();
-
-        // Loop over all field names
-        // Flag for if this is the first variable
-        let mut is_first = true;
-        for field in partial_application.0.iter() {
-            if let JobApplicationField::Id(_) = field {
-                // NO-OP: Id is special because we are using it in the WHERE clause instead of SET
-            } else if is_first {
-                // The first non-id value is special because of where the SET and commas are
-                query_builder += &format!(" SET {0} = :{0}", field.name());
-                is_first = false
-            } else {
-                // Normal placement
-                query_builder += &format!(",\n{0} = :{0}", field.name());
-            }
-        }
-
-        // End with the WHERE clause
-        query_builder += "\nWHERE id = :id";
-        // RETURNING id, source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes";
-
-        self.exec_drop(query_builder, partial_application)
-    }
-
-    fn delete_job_application(&mut self, id: i32) -> Result<(), mysql::Error> {
-        self.exec_drop(
-            "DELETE FROM job_applications WHERE id = :id",
-            params! {"id" => id},
-        )
-    }
 }

--- a/repository/src/job_application_repository/mysql_backend.rs
+++ b/repository/src/job_application_repository/mysql_backend.rs
@@ -1,0 +1,139 @@
+use mysql::{params, prelude::Queryable};
+
+use crate::job_application_model::JobApplicationField;
+
+use super::*;
+
+impl<C> JobApplicationRepository for C
+where
+    C: Queryable,
+{
+    type Error = mysql::Error;
+
+    fn get_job_applications(&mut self) -> Result<Vec<JobApplication>, mysql::Error> {
+        self.query(
+        "SELECT id, source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes
+        FROM job_applications"
+    )
+    }
+
+    fn get_pending_job_applications(&mut self) -> Result<Vec<JobApplication>, mysql::Error> {
+        self.query(
+        "SELECT id, source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes
+        FROM job_applications
+        WHERE human_response = 'N'"
+    )
+    }
+
+    fn get_job_application_by_id(
+        &mut self,
+        id: i32,
+    ) -> Result<Option<JobApplication>, mysql::Error> {
+        self.exec_first(
+        "SELECT id, source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes
+        FROM job_applications
+        WHERE id = ?",
+        (id,),
+    )
+    }
+
+    fn search_job_applications(
+        &mut self,
+        query: &str,
+    ) -> Result<Vec<JobApplication>, mysql::Error> {
+        // Add wildcards to the beginning and end of the query
+        let query_with_wildcards = "%".to_owned() + &query.to_lowercase() + "%";
+        self.exec(
+        "SELECT id, source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes
+        FROM job_applications
+        WHERE LOWER(source) LIKE :query
+        OR LOWER(company) LIKE :query
+        OR LOWER(job_title) LIKE :query",
+        params! {"query" => query_with_wildcards}
+    )
+    }
+
+    fn insert_job_application(
+        &mut self,
+        application: &JobApplication,
+    ) -> Result<JobApplication, mysql::Error> {
+        self.exec_first(
+        "INSERT INTO job_applications (source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes)
+        VALUES (:source, :company, :job_title, :application_date, :time_investment, :human_response, :human_response_date, :application_website, :notes)
+        RETURNING id",
+        application
+    )
+    .map(|new_id| JobApplication {id: new_id.unwrap_or_default(), ..application.clone()})
+    }
+
+    fn update_human_response(
+        &mut self,
+        id: i32,
+        human_response: HumanResponse,
+        human_response_date: Option<Date>,
+    ) -> Result<(), mysql::Error> {
+        self.exec_drop(
+            "UPDATE job_applications
+        SET human_response = :human_response, human_response_date = :human_response_date
+        WHERE id = :id",
+            params! {
+                "id" => id,
+                "human_response" => &human_response,
+                "human_response_date" => human_response_date
+            },
+        )
+    }
+
+    fn update_job_application(&mut self, application: &JobApplication) -> Result<(), mysql::Error> {
+        self.exec_drop(
+            "UPDATE job_applications
+        SET source = :source,
+        company = :company,
+        job_title = :job_title,
+        application_date = :application_date,
+        time_investment = :time_investment,
+        human_response = :human_response,
+        human_response_date = :human_response_date,
+        application_website = :application_website,
+        notes = :notes
+        WHERE id = :id",
+            application,
+        )
+    }
+
+    fn update_job_application_partial(
+        &mut self,
+        partial_application: PartialJobApplication,
+    ) -> Result<(), mysql::Error> {
+        let mut query_builder = "UPDATE job_applications".to_owned();
+
+        // Loop over all field names
+        // Flag for if this is the first variable
+        let mut is_first = true;
+        for field in partial_application.0.iter() {
+            if let JobApplicationField::Id(_) = field {
+                // NO-OP: Id is special because we are using it in the WHERE clause instead of SET
+            } else if is_first {
+                // The first non-id value is special because of where the SET and commas are
+                query_builder += &format!(" SET {0} = :{0}", field.name());
+                is_first = false
+            } else {
+                // Normal placement
+                query_builder += &format!(",\n{0} = :{0}", field.name());
+            }
+        }
+
+        // End with the WHERE clause
+        query_builder += "\nWHERE id = :id";
+        // RETURNING id, source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes";
+
+        self.exec_drop(query_builder, partial_application)
+    }
+
+    fn delete_job_application(&mut self, id: i32) -> Result<(), mysql::Error> {
+        self.exec_drop(
+            "DELETE FROM job_applications WHERE id = :id",
+            params! {"id" => id},
+        )
+    }
+}

--- a/repository/src/job_application_repository/mysql_backend.rs
+++ b/repository/src/job_application_repository/mysql_backend.rs
@@ -123,6 +123,12 @@ where
             }
         }
 
+                // Assert there is at least one change
+                if is_first {
+                    // Use `std::io::Error` to return an arbitrary `mysql::Error`
+                    return Err(std::io::Error::other("Unable to generate SQL statement because there are no changes").into());
+                }
+
         // End with the WHERE clause
         query_builder += "\nWHERE id = :id";
         // RETURNING id, source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes";

--- a/repository/src/job_application_repository/sqlite_backend.rs
+++ b/repository/src/job_application_repository/sqlite_backend.rs
@@ -1,0 +1,67 @@
+use rusqlite::Connection;
+
+use super::JobApplicationRepository;
+
+impl JobApplicationRepository for Connection {
+    type Error = rusqlite::Error;
+
+    fn get_job_applications(
+        &mut self,
+    ) -> Result<Vec<crate::job_application_model::JobApplication>, Self::Error> {
+        todo!()
+    }
+
+    fn get_pending_job_applications(
+        &mut self,
+    ) -> Result<Vec<crate::job_application_model::JobApplication>, Self::Error> {
+        todo!()
+    }
+
+    fn get_job_application_by_id(
+        &mut self,
+        id: i32,
+    ) -> Result<Option<crate::job_application_model::JobApplication>, Self::Error> {
+        todo!()
+    }
+
+    fn search_job_applications(
+        &mut self,
+        query: &str,
+    ) -> Result<Vec<crate::job_application_model::JobApplication>, Self::Error> {
+        todo!()
+    }
+
+    fn insert_job_application(
+        &mut self,
+        application: &crate::job_application_model::JobApplication,
+    ) -> Result<crate::job_application_model::JobApplication, Self::Error> {
+        todo!()
+    }
+
+    fn update_human_response(
+        &mut self,
+        id: i32,
+        human_response: crate::job_application_model::HumanResponse,
+        human_response_date: Option<time::Date>,
+    ) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    fn update_job_application(
+        &mut self,
+        application: &crate::job_application_model::JobApplication,
+    ) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    fn update_job_application_partial(
+        &mut self,
+        partial_application: crate::job_application_model::PartialJobApplication,
+    ) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    fn delete_job_application(&mut self, id: i32) -> Result<(), Self::Error> {
+        todo!()
+    }
+}

--- a/repository/src/job_application_repository/sqlite_backend.rs
+++ b/repository/src/job_application_repository/sqlite_backend.rs
@@ -169,6 +169,13 @@ impl JobApplicationRepository for Connection {
             }
         }
 
+        // Assert there is at least one change
+        if is_first {
+            return Err(rusqlite::Error::ToSqlConversionFailure(Box::from(
+                "Unable to generate SQL statement because there are no changes",
+            )));
+        }
+
         // End with the WHERE clause
         query_builder += &format!(
             "\nWHERE id = ?{}",

--- a/repository/src/job_application_repository/sqlite_backend.rs
+++ b/repository/src/job_application_repository/sqlite_backend.rs
@@ -1,7 +1,9 @@
-use rusqlite::{named_params, Connection};
-use time::Duration;
+use rusqlite::{named_params, params_from_iter, Connection, OptionalExtension, Params, ToSql};
+use time::{Date, Duration};
 
-use crate::job_application_model::{JobApplication, PartialJobApplication};
+use crate::job_application_model::{
+    HumanResponse, JobApplication, JobApplicationField, PartialJobApplication,
+};
 
 use super::JobApplicationRepository;
 
@@ -9,39 +11,51 @@ impl JobApplicationRepository for Connection {
     type Error = rusqlite::Error;
 
     fn get_job_applications(&mut self) -> Result<Vec<JobApplication>, Self::Error> {
-        // Create a prepared statement object
-        let mut stmt = self.prepare_cached(
+        execute_query(
+            self,
             "SELECT id, source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes \
-            FROM job_applications"
-        )?;
-
-        // Execute the statement, which will return an iterator to the mapped rows
-        let row_iter = stmt.query_map((), |row| row.try_into())?;
-
-        // Collect into a Vec using a for loop because we can't effectively use collect the iterator using `Iterator::collect`.
-        // This is because we want the row mapping result to be passed to the caller on error using the `?` operator.
-        let mut row_vec: Vec<JobApplication> = Vec::new();
-        for row in row_iter {
-            row_vec.push(row?);
-        }
-
-        // Return the collected Vec
-        Ok(row_vec)
+            FROM job_applications",
+            ()
+        )
     }
 
     fn get_pending_job_applications(&mut self) -> Result<Vec<JobApplication>, Self::Error> {
-        todo!()
+        execute_query(
+            self,
+            "SELECT id, source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes \
+            FROM job_applications \
+            WHERE human_response = 'N'",
+            ()
+        )
     }
 
     fn get_job_application_by_id(
         &mut self,
         id: i32,
     ) -> Result<Option<JobApplication>, Self::Error> {
-        todo!()
+        let mut stmt = self.prepare_cached("SELECT id, source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes \
+            FROM job_applications \
+            WHERE id = ?"
+        )?;
+
+        // Execute the statement
+        // At most one row can be returned when querying by primary key
+        stmt.query_row((id,), |row| row.try_into()).optional()
     }
 
     fn search_job_applications(&mut self, query: &str) -> Result<Vec<JobApplication>, Self::Error> {
-        todo!()
+        // Add wildcards to query
+        let query_with_wildcards = "%".to_owned() + &query.to_lowercase() + "%";
+
+        execute_query(
+            self,
+            "SELECT id, source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes \
+            FROM job_applications \
+            WHERE LOWER(source) LIKE ?1 \
+            OR LOWER(company) LIKE ?1 \
+            OR LOWER(job_title) LIKE ?1",
+        (query_with_wildcards,)
+        )
     }
 
     fn insert_job_application(
@@ -72,24 +86,137 @@ impl JobApplicationRepository for Connection {
     fn update_human_response(
         &mut self,
         id: i32,
-        human_response: crate::job_application_model::HumanResponse,
-        human_response_date: Option<time::Date>,
+        human_response: HumanResponse,
+        human_response_date: Option<Date>,
     ) -> Result<(), Self::Error> {
-        todo!()
+        let mut stmt = self.prepare_cached(
+            "UPDATE job_applications \
+            SET human_response = :human_response, human_response_date = :human_response_date \
+            WHERE id = :id",
+        )?;
+
+        stmt.execute(named_params! {
+            ":id": id,
+            ":human_response": human_response,
+            ":human_response_date": human_response_date,
+        })
+        .map(|_| ())
     }
 
     fn update_job_application(&mut self, application: &JobApplication) -> Result<(), Self::Error> {
-        todo!()
+        let mut stmt = self.prepare_cached(
+            "UPDATE job_applications \
+            SET source = :source, \
+            company = :company, \
+            job_title = :job_title, \
+            application_date = :application_date, \
+            time_investment = :time_investment, \
+            human_response = :human_response, \
+            human_response_date = :human_response_date, \
+            application_website = :application_website, \
+            notes = :notes \
+            WHERE id = :id",
+        )?;
+
+        stmt.execute(named_params! {
+            ":id": application.id,
+            ":source": application.source,
+            ":company": application.company,
+            ":job_title": application.job_title,
+            ":application_date": application.application_date,
+            ":time_investment": application.time_investment.map(Duration::whole_seconds),
+            ":human_response": application.human_response,
+            ":human_response_date": application.human_response_date,
+            ":application_website": application.application_website,
+            ":notes": application.notes,
+        })
+        .map(|_| ())
     }
 
     fn update_job_application_partial(
         &mut self,
         partial_application: PartialJobApplication,
     ) -> Result<(), Self::Error> {
-        todo!()
+        // Build the query parameters in a string
+        // This is necessary because we only want to modify the given columns
+        // This is not a SQLi vulnerability because we will only be using this for the names, which are defined statically in `JobApplicationField::name()`
+        let mut query_builder = "UPDATE job_applications".to_owned();
+
+        let mut id_index: Option<usize> = None;
+
+        // Loop over all field names
+        // Flag for if this is the first variable
+        // We still need this, even though we are looping over an index, because id should not affect first
+        let mut is_first = true;
+        for (index, field) in partial_application.0.iter().enumerate() {
+            if let JobApplicationField::Id(_) = field {
+                // Id is special because we are using it in the WHERE clause instead of SET
+                // Ensure there is only one id. If there are more the statement will fail
+                if id_index.is_none() {
+                    id_index = Some(index + 1);
+                } else {
+                    return Err(rusqlite::Error::ToSqlConversionFailure(Box::from(
+                        "Unable to generate SQL statement because there are multiple id fields",
+                    )));
+                }
+            } else if is_first {
+                // The first non-id value is special because of where the SET and commas are
+                query_builder += &format!(" SET {} = ?{}", field.name(), index + 1);
+                is_first = false
+            } else {
+                // Normal placement
+                query_builder += &format!(",\n{} = ?{}", field.name(), index + 1);
+            }
+        }
+
+        // End with the WHERE clause
+        query_builder += &format!(
+            "\nWHERE id = ?{}",
+            id_index.ok_or(rusqlite::Error::ToSqlConversionFailure(Box::from(
+                "Unable to generate SQL statement because there is no id field"
+            )))?
+        );
+
+        // Now that we have the statement, prepare it
+        // We will not be caching this due to the variance in the number of ways to represent this query
+        let mut stmt = self.prepare(&query_builder)?;
+
+        // Finally, execute returning Result<()>
+        stmt.execute(params_from_iter(Into::<Vec<Box<dyn ToSql>>>::into(
+            partial_application,
+        )))
+        .map(|_| ())
     }
 
     fn delete_job_application(&mut self, id: i32) -> Result<(), Self::Error> {
-        todo!()
+        let mut stmt = self.prepare_cached("DELETE FROM job_applications WHERE id = ?")?;
+
+        stmt.execute((id,)).map(|_| ())
     }
+}
+
+/// Internal method to make a query where multiple rows are returned easier
+///
+/// This function exists for sqlite but not mysql because the sqlite query process has much more boilerplate
+fn execute_query<P: Params>(
+    conn: &mut Connection,
+    sql: &str,
+    params: P,
+) -> Result<Vec<JobApplication>, rusqlite::Error> {
+    // Create a prepared statement object
+    let mut stmt = conn.prepare_cached(sql)?;
+
+    // Execute the statement, which will return an iterator to the mapped rows
+    // For some reason, using `TryInto::try_into` gives an error message, but calling within a closure doesn't
+    let row_iter = stmt.query_map(params, |row| row.try_into())?;
+
+    // Collect into a Vec using a for loop because we can't effectively use collect the iterator using `Iterator::collect`.
+    // This is because we want the row mapping result to be passed to the caller on error using the `?` operator.
+    let mut row_vec: Vec<JobApplication> = Vec::new();
+    for row in row_iter {
+        row_vec.push(row?);
+    }
+
+    // Return the collected Vec
+    Ok(row_vec)
 }

--- a/repository/src/job_application_repository/sqlite_backend.rs
+++ b/repository/src/job_application_repository/sqlite_backend.rs
@@ -1,41 +1,72 @@
-use rusqlite::Connection;
+use rusqlite::{named_params, Connection};
+use time::Duration;
+
+use crate::job_application_model::{JobApplication, PartialJobApplication};
 
 use super::JobApplicationRepository;
 
 impl JobApplicationRepository for Connection {
     type Error = rusqlite::Error;
 
-    fn get_job_applications(
-        &mut self,
-    ) -> Result<Vec<crate::job_application_model::JobApplication>, Self::Error> {
-        todo!()
+    fn get_job_applications(&mut self) -> Result<Vec<JobApplication>, Self::Error> {
+        // Create a prepared statement object
+        let mut stmt = self.prepare_cached(
+            "SELECT id, source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes \
+            FROM job_applications"
+        )?;
+
+        // Execute the statement, which will return an iterator to the mapped rows
+        let row_iter = stmt.query_map((), |row| row.try_into())?;
+
+        // Collect into a Vec using a for loop because we can't effectively use collect the iterator using `Iterator::collect`.
+        // This is because we want the row mapping result to be passed to the caller on error using the `?` operator.
+        let mut row_vec: Vec<JobApplication> = Vec::new();
+        for row in row_iter {
+            row_vec.push(row?);
+        }
+
+        // Return the collected Vec
+        Ok(row_vec)
     }
 
-    fn get_pending_job_applications(
-        &mut self,
-    ) -> Result<Vec<crate::job_application_model::JobApplication>, Self::Error> {
+    fn get_pending_job_applications(&mut self) -> Result<Vec<JobApplication>, Self::Error> {
         todo!()
     }
 
     fn get_job_application_by_id(
         &mut self,
         id: i32,
-    ) -> Result<Option<crate::job_application_model::JobApplication>, Self::Error> {
+    ) -> Result<Option<JobApplication>, Self::Error> {
         todo!()
     }
 
-    fn search_job_applications(
-        &mut self,
-        query: &str,
-    ) -> Result<Vec<crate::job_application_model::JobApplication>, Self::Error> {
+    fn search_job_applications(&mut self, query: &str) -> Result<Vec<JobApplication>, Self::Error> {
         todo!()
     }
 
     fn insert_job_application(
         &mut self,
-        application: &crate::job_application_model::JobApplication,
-    ) -> Result<crate::job_application_model::JobApplication, Self::Error> {
-        todo!()
+        application: &JobApplication,
+    ) -> Result<JobApplication, Self::Error> {
+        self.prepare_cached(
+            "INSERT INTO job_applications (source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes) \
+                VALUES (:source, :company, :job_title, :application_date, :time_investment, :human_response, :human_response_date, :application_website, :notes)")?
+            // If the preparation succeeded, insert the row
+            .insert(
+                named_params! {
+                    ":source": application.source,
+                    ":company": application.company,
+                    ":job_title": application.job_title,
+                    ":application_date": application.application_date,
+                    ":time_investment": application.time_investment.map(Duration::whole_seconds),
+                    ":human_response": application.human_response,
+                    ":human_response_date": application.human_response_date,
+                    ":application_website": application.application_website,
+                    ":notes": application.notes,
+                }
+            )
+            // If that succeeded, return the new job application
+            .map(|id| JobApplication {id: id as i32, ..application.clone()})
     }
 
     fn update_human_response(
@@ -47,16 +78,13 @@ impl JobApplicationRepository for Connection {
         todo!()
     }
 
-    fn update_job_application(
-        &mut self,
-        application: &crate::job_application_model::JobApplication,
-    ) -> Result<(), Self::Error> {
+    fn update_job_application(&mut self, application: &JobApplication) -> Result<(), Self::Error> {
         todo!()
     }
 
     fn update_job_application_partial(
         &mut self,
-        partial_application: crate::job_application_model::PartialJobApplication,
+        partial_application: PartialJobApplication,
     ) -> Result<(), Self::Error> {
         todo!()
     }

--- a/repository/src/lib.rs
+++ b/repository/src/lib.rs
@@ -54,6 +54,7 @@ mod backend_connection {
         // The ats-tracking.db3 file should be placed in the user's home directory
 
         // The reason this is deprecated is fixed in Rust 1.85 and the deprecation notice will be removed soon.
+        #[allow(deprecated)]
         let home = std::env::home_dir().unwrap_or_else(|| {
             // If home_dir() fails, use current working directory
             eprintln!(
@@ -162,13 +163,4 @@ mod backend_connection {
             Ok(())
         }
     }
-}
-
-/// Tests module
-///
-/// Currently only sqlite can be tested because it's easier to do integration tests on.
-#[cfg(test)]
-mod tests {
-    #[cfg(not(feature = "mysql"))]
-    mod sqlite_tests;
 }

--- a/repository/src/lib.rs
+++ b/repository/src/lib.rs
@@ -20,20 +20,30 @@ mod backend_connection {
         let mut sql_opts_builder = OptsBuilder::new();
         if let Ok(host_name) = env::var("DB_HOST") {
             sql_opts_builder = sql_opts_builder.ip_or_hostname(Some(host_name));
+        } else {
+            eprintln!("Warning: DB_HOST not defined, using default");
         }
         if let Ok(port_str) = env::var("DB_PORT") {
             if let Ok(port_int) = port_str.parse::<u16>() {
                 sql_opts_builder = sql_opts_builder.tcp_port(port_int);
             }
+        } else {
+            eprintln!("Warning: DB_PORT not defined, using default");
         }
         if let Ok(user) = env::var("DB_USER") {
             sql_opts_builder = sql_opts_builder.user(Some(user));
+        } else {
+            eprintln!("Warning: DB_USER not defined");
         }
         if let Ok(pass) = env::var("DB_PASSWORD") {
             sql_opts_builder = sql_opts_builder.pass(Some(pass));
+        } else {
+            eprintln!("Warning: DB_PASSWORD not defined")
         }
         if let Ok(db_name) = env::var("DB_DATABASE") {
             sql_opts_builder = sql_opts_builder.db_name(Some(db_name));
+        } else {
+            eprintln!("Warning: DB_DATABASE not defined")
         }
 
         let pool = Pool::new(sql_opts_builder)?;

--- a/repository/src/lib.rs
+++ b/repository/src/lib.rs
@@ -1,37 +1,165 @@
 //! Job application repository with a MySQL database
 
-use std::env;
-
-use mysql::{OptsBuilder, Pool, PooledConn};
-
 /// Define `struct JobApplication` and some implement conversions between that and MySQL objects
 pub mod job_application_model;
 /// Define CRUD actions for `struct JobApplication` into the MySQL database
 pub mod job_application_repository;
 
-/// Get a connection object to be used by the rest of this crate
-///
-/// This exists so that the main function can own the connection object instead of creating a new one for every call
-pub fn get_conn() -> Result<PooledConn, mysql::Error> {
-    let mut sql_opts_builder = OptsBuilder::new();
-    if let Ok(host_name) = env::var("DB_HOST") {
-        sql_opts_builder = sql_opts_builder.ip_or_hostname(Some(host_name));
-    }
-    if let Ok(port_str) = env::var("DB_PORT") {
-        if let Ok(port_int) = port_str.parse::<u16>() {
-            sql_opts_builder = sql_opts_builder.tcp_port(port_int);
+pub use backend_connection::get_conn;
+
+#[cfg(feature = "mysql")]
+mod backend_connection {
+    use std::env;
+
+    use mysql::{OptsBuilder, Pool, PooledConn};
+
+    /// Get a connection object to be used by the rest of this crate
+    ///
+    /// This exists so that the main function can own the connection object instead of creating a new one for every call
+    pub fn get_conn() -> Result<PooledConn, mysql::Error> {
+        let mut sql_opts_builder = OptsBuilder::new();
+        if let Ok(host_name) = env::var("DB_HOST") {
+            sql_opts_builder = sql_opts_builder.ip_or_hostname(Some(host_name));
         }
+        if let Ok(port_str) = env::var("DB_PORT") {
+            if let Ok(port_int) = port_str.parse::<u16>() {
+                sql_opts_builder = sql_opts_builder.tcp_port(port_int);
+            }
+        }
+        if let Ok(user) = env::var("DB_USER") {
+            sql_opts_builder = sql_opts_builder.user(Some(user));
+        }
+        if let Ok(pass) = env::var("DB_PASSWORD") {
+            sql_opts_builder = sql_opts_builder.pass(Some(pass));
+        }
+        if let Ok(db_name) = env::var("DB_DATABASE") {
+            sql_opts_builder = sql_opts_builder.db_name(Some(db_name));
+        }
+
+        let pool = Pool::new(sql_opts_builder)?;
+        pool.get_conn()
     }
-    if let Ok(user) = env::var("DB_USER") {
-        sql_opts_builder = sql_opts_builder.user(Some(user));
-    }
-    if let Ok(pass) = env::var("DB_PASSWORD") {
-        sql_opts_builder = sql_opts_builder.pass(Some(pass));
-    }
-    if let Ok(db_name) = env::var("DB_DATABASE") {
-        sql_opts_builder = sql_opts_builder.db_name(Some(db_name));
+}
+
+#[cfg(not(feature = "mysql"))]
+mod backend_connection {
+    use std::path::{Path, PathBuf};
+
+    use rusqlite::Connection;
+
+    /// Get a connection object to be used by the rest of this crate
+    ///
+    /// This exists so that the main function can own the connection object instead of creating a new one for every call
+    pub fn get_conn() -> Result<Connection, rusqlite::Error> {
+        // The ats-tracking.db3 file should be placed in the user's home directory
+
+        // The reason this is deprecated is fixed in Rust 1.85 and the deprecation notice will be removed soon.
+        let home = std::env::home_dir().unwrap_or_else(|| {
+            // If home_dir() fails, use current working directory
+            eprintln!(
+                "Unable to find home directory. Using current directory for ats-tracking.db3"
+            );
+            PathBuf::from(".")
+        });
+
+        get_or_make_db(home.join("/ats-tracking.db3"))
     }
 
-    let pool = Pool::new(sql_opts_builder)?;
-    pool.get_conn()
+    /// Get connection for a path and ensure the job_applications table exists
+    fn get_or_make_db<P: AsRef<Path>>(path: P) -> Result<Connection, rusqlite::Error> {
+        // Get connection
+        let conn = Connection::open(path)?;
+
+        // Ensure the table exists
+        conn.execute(include_str!("resources/sqlite_table_definition.sql"), ())?;
+
+        // Return conn
+        Ok(conn)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use tempfile::TempDir;
+
+        use super::*;
+
+        #[test]
+        fn test_new_db() -> Result<(), Box<dyn std::error::Error>> {
+            let expected_tbl_name = "job_applications";
+            // Generates a 1 if the table exists, or a 0 if the table doesn't exist
+            let expected_tbl_sql =
+                "SELECT EXISTS(SELECT 1 FROM sqlite_schema WHERE type = 'table' AND tbl_name = ?1)";
+
+            // Create a new directory for the database
+            let path = TempDir::new()?;
+            let db_path = path.path().join("test_db.db3");
+
+            let conn = get_or_make_db(db_path)?;
+
+            assert_eq!(
+                1,
+                conn.query_row(expected_tbl_sql, (expected_tbl_name,), |row| row
+                    .get::<usize, i32>(0)
+                    .map(Into::<i32>::into))?
+            );
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_existing_db() -> Result<(), Box<dyn std::error::Error>> {
+            // Create db path
+            let path = TempDir::new()?;
+            let db_path = path.path().join("test_db.db3");
+
+            let job_application_id: i64;
+            let test_data = (
+                "test source".to_string(),
+                "test company".to_string(),
+                "test job title".to_string(),
+                "test application date".to_string(),
+                3,
+                "R".to_string(),
+                "test human response date".to_string(),
+                "test application website".to_string(),
+                "test notes".to_string(),
+            );
+
+            // Create new database table and insert a row
+            {
+                let conn = get_or_make_db(&db_path)?;
+
+                job_application_id = conn.prepare("INSERT INTO job_applications (source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes) \
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")?
+                    .insert(test_data.clone()).expect("INSERT FAIL");
+            }
+
+            // The earlier conn should now be dropped, so we can connect to the file with a new connection
+            let conn = get_or_make_db(&db_path)?;
+
+            // Now that we have a new connection, the earlier data should still exist
+            assert_eq!(
+                test_data,
+                conn.prepare("SELECT source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes FROM job_applications WHERE id = ?")?
+                    .query_row((job_application_id,), |row| {
+                        Ok((
+                            row.get::<usize, _>(0)?,
+                            row.get::<usize, _>(1)?,
+                            row.get::<usize, _>(2)?,
+                            row.get::<usize, _>(3)?,
+                            row.get::<usize, _>(4)?,
+                            row.get::<usize, _>(5)?,
+                            row.get::<usize, _>(6)?,
+                            row.get::<usize, _>(7)?,
+                            row.get::<usize, _>(8)?
+                        ))
+                    }).map_err(|e| match e {
+                        rusqlite::Error::QueryReturnedNoRows => "New database connection failed to use existing database.".to_string(),
+                        _ => format!("{e}")
+                    })?
+            );
+
+            Ok(())
+        }
+    }
 }

--- a/repository/src/lib.rs
+++ b/repository/src/lib.rs
@@ -62,7 +62,7 @@ mod backend_connection {
             PathBuf::from(".")
         });
 
-        get_or_make_db(home.join("/ats-tracking.db3"))
+        get_or_make_db(home.join("ats-tracking.db3"))
     }
 
     /// Get connection for a path and ensure the job_applications table exists

--- a/repository/src/lib.rs
+++ b/repository/src/lib.rs
@@ -163,3 +163,12 @@ mod backend_connection {
         }
     }
 }
+
+/// Tests module
+///
+/// Currently only sqlite can be tested because it's easier to do integration tests on.
+#[cfg(test)]
+mod tests {
+    #[cfg(not(feature = "mysql"))]
+    mod sqlite_tests;
+}

--- a/repository/src/resources/sqlite_table_definition.sql
+++ b/repository/src/resources/sqlite_table_definition.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS job_applications (
+    id INTEGER PRIMARY KEY,
+    source TEXT NOT NULL,
+    company TEXT NOT NULL,
+    job_title TEXT NOT NULL,
+    application_date TEXT NOT NULL,
+    time_investment INTEGER,
+    human_response TEXT CHECK(human_response IN ('N','R','I')) NOT NULL DEFAULT 'N',
+    human_response_date TEXT,
+    application_website TEXT,
+    notes TEXT
+);

--- a/repository/src/tests/sqlite_tests.rs
+++ b/repository/src/tests/sqlite_tests.rs
@@ -8,6 +8,9 @@ use crate::{
     job_application_repository::JobApplicationRepository,
 };
 
+// I attempted to make the tests only test one function, but manually operating on the DB got annoying.
+// Starting with [test_search_job_applications], I decided to just use all necessary functions to make writing the tests easier.
+
 /// Test [JobApplicationRepository::get_job_applications] where the table has no rows
 #[test]
 fn test_get_job_applications_none() -> Result<(), Box<dyn std::error::Error>> {
@@ -219,21 +222,222 @@ fn test_get_pending_job_applications() -> Result<(), Box<dyn std::error::Error>>
     Ok(())
 }
 
+/// Test [JobApplicationRepository::get_job_application_by_id]
+///
+/// Tests that existent job applications cause the function to return `Ok(Some(...))`
+/// and that non-existent job applications return `Ok(None}`.
 #[test]
 fn test_get_job_application_by_id() -> Result<(), Box<dyn std::error::Error>> {
     let mut conn = get_memory_connection()?;
+
+    let source = "Test source";
+    let company = "Test company";
+    let job_title = "Test job title";
+    let application_date = "2000-01-01";
+    let time_investment = 83; // 1:23
+    let human_response = HumanResponse::Rejection;
+    let human_response_date = "2000-01-02";
+    let application_website = "http://example.com";
+    let notes = "Test notes\nWith newline";
+
+    // Insert three job applications with known fields
+    // This will insert 3 copies of the same values, but that's unlikely to miss any bugs
+    conn.execute(
+        "INSERT INTO job_applications (id, source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes) \
+        VALUES (1, :source, :company, :job_title, :application_date, :time_investment, :human_response, :human_response_date, :application_website, :notes), \
+        (2, :source, :company, :job_title, :application_date, :time_investment, :human_response, :human_response_date, :application_website, :notes), \
+        (3, :source, :company, :job_title, :application_date, :time_investment, :human_response, :human_response_date, :application_website, :notes)",
+        named_params! {
+            ":source": source,
+            ":company": company,
+            ":job_title": job_title,
+            ":application_date": application_date,
+            ":time_investment": time_investment,
+            ":human_response": human_response,
+            ":human_response_date": human_response_date,
+            ":application_website": application_website,
+            ":notes": notes,
+        }
+    )?;
+
+    assert_eq!(
+        conn.get_job_application_by_id(2)?,
+        Some(JobApplication {
+            id: 2,
+            source: source.to_string(),
+            company: company.to_string(),
+            job_title: job_title.to_string(),
+            application_date: Date::from_calendar_date(2000, Month::January, 1).unwrap(),
+            time_investment: Some(time_investment.seconds()),
+            human_response,
+            human_response_date: Some(Date::from_calendar_date(2000, Month::January, 2).unwrap()),
+            application_website: Some(application_website.to_string()),
+            notes: Some(notes.to_string()),
+        }),
+        "Job application ID 2 should find a job application"
+    );
+
+    assert_eq!(
+        conn.get_job_application_by_id(4)?,
+        None,
+        "Job application ID 4 should not find anything"
+    );
+
     Ok(())
 }
 
+/// Test [JobApplicationRepository::search_job_applications]
+///
+/// Should find all where the source, company, or job_title contains the search string.
+/// Additionally, it should be case insensitive.
 #[test]
 fn test_search_job_applications() -> Result<(), Box<dyn std::error::Error>> {
     let mut conn = get_memory_connection()?;
+
+    // Search string and a case-inverted version
+    let search_string = "SeArCh StRiNg";
+    let search_string_invert_case = "sEaRcH sTrInG";
+
+    // Base job application without search string
+    let job_application_base = JobApplication {
+        id: 1,
+        source: "Test source".to_string(),
+        company: "Test company".to_string(),
+        job_title: "Test job title".to_string(),
+        application_date: Date::from_calendar_date(2000, Month::January, 1).unwrap(),
+        time_investment: None,
+        human_response: HumanResponse::None,
+        human_response_date: None,
+        application_website: None,
+        notes: None,
+    };
+
+    // Id for the base job application, which should not match
+    let JobApplication { id: id_base, .. } = conn.insert_job_application(&job_application_base)?;
+
+    // Id for job application where source matches
+    let JobApplication { id: id_source, .. } = conn.insert_job_application(&JobApplication {
+        source: "aaa".to_string() + search_string + "bbb",
+        ..job_application_base.clone()
+    })?;
+
+    // Id for job application where company matches
+    let JobApplication { id: id_company, .. } = conn.insert_job_application(&JobApplication {
+        company: "aaa".to_string() + search_string,
+        ..job_application_base.clone()
+    })?;
+
+    // Id for job application where job_title matches
+    let JobApplication {
+        id: id_job_title, ..
+    } = conn.insert_job_application(&JobApplication {
+        job_title: search_string.to_string(),
+        ..job_application_base
+    })?;
+
+    let job_applications = conn.search_job_applications(&search_string)?;
+
+    // Assert all job applications that should match do match
+    for (name, id) in [
+        ("source", id_source),
+        ("company", id_company),
+        ("job_title", id_job_title),
+    ] {
+        assert!(
+            job_applications
+                .iter()
+                .any(|job_application| job_application.id == id),
+            "{name} should produce a match"
+        );
+    }
+
+    // And the base does not match
+    assert!(
+        !job_applications
+            .iter()
+            .any(|job_application| job_application.id == id_base),
+        "The base job application should produce a match"
+    );
+
+    // Do the same for when the query would not match if it was case sensitive
+    let job_applications_inverted_query = conn.search_job_applications(&search_string_invert_case)?;
+
+    for (name, id) in [
+        ("source", id_source),
+        ("company", id_company),
+        ("job_title", id_job_title),
+    ] {
+        assert!(
+            job_applications_inverted_query
+                .iter()
+                .any(|job_application| job_application.id == id),
+            "{name} should produce a match, even though the case does not match"
+        );
+    }
+
+    assert!(
+        !job_applications_inverted_query
+            .iter()
+            .any(|job_application| job_application.id == id_base),
+        "The base job application should produce a match"
+    );
+
     Ok(())
 }
 
+/// Test [JobApplicationRepository::insert_job_application]
 #[test]
 fn test_insert_job_application() -> Result<(), Box<dyn std::error::Error>> {
     let mut conn = get_memory_connection()?;
+
+    let job_application = JobApplication {
+        id: 0,
+        source: "Test source".to_string(),
+        company: "Test company".to_string(),
+        job_title: "Test job title".to_string(),
+        application_date: Date::from_calendar_date(2000, Month::January, 1).unwrap(),
+        time_investment: None,
+        human_response: HumanResponse::None,
+        human_response_date: None,
+        application_website: None,
+        notes: None,
+    };
+
+    let JobApplication { id: id_1, .. } = conn.insert_job_application(&job_application)?;
+
+    assert_eq!(id_1, 1, "Job applications should insert starting with id 1");
+
+    assert_eq!(
+        conn.get_job_application_by_id(id_1)?,
+        Some(JobApplication {
+            id: id_1,
+            ..job_application.clone()
+        }),
+        "The job application should be able to be retrieved after being inserted"
+    );
+
+    let job_application_2 = JobApplication {
+        time_investment: Some(90.seconds()),
+        human_response: HumanResponse::Rejection,
+        human_response_date: Some(Date::from_calendar_date(2000, Month::February, 2).unwrap()),
+        application_website: Some("http://example.com".to_string()),
+        notes: Some("Example\nNotes".to_string()),
+        ..job_application
+    };
+
+    let JobApplication { id: id_2, .. } = conn.insert_job_application(&job_application_2)?;
+
+    assert_eq!(id_2, 2, "The second job application should have id 2");
+
+    assert_eq!(
+        conn.get_job_application_by_id(id_2)?,
+        Some(JobApplication {
+            id: id_2,
+            ..job_application_2
+        }),
+        "The second job application should be able to be retrieved after being inserted"
+    );
+
     Ok(())
 }
 
@@ -261,6 +465,7 @@ fn test_delete_job_application() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// Not a test. Just a helper function to generate empty memory connections.
 fn get_memory_connection() -> Result<Connection, rusqlite::Error> {
     let conn = Connection::open_in_memory()?;
 

--- a/repository/src/tests/sqlite_tests.rs
+++ b/repository/src/tests/sqlite_tests.rs
@@ -1,0 +1,270 @@
+//! Integration tests for the SQLite implementation
+
+use rusqlite::{named_params, Connection};
+use time::{ext::NumericalDuration as _, Date, Month};
+
+use crate::{
+    job_application_model::{HumanResponse, JobApplication},
+    job_application_repository::JobApplicationRepository,
+};
+
+/// Test [JobApplicationRepository::get_job_applications] where the table has no rows
+#[test]
+fn test_get_job_applications_none() -> Result<(), Box<dyn std::error::Error>> {
+    let mut conn = get_memory_connection()?;
+
+    let job_applications = conn.get_job_applications()?;
+
+    assert_eq!(
+        job_applications,
+        vec![],
+        "Expected empty Vec when table is empty, got {job_applications:?}"
+    );
+
+    Ok(())
+}
+
+/// Test [JobApplicationRepository::get_job_applications] where the table has exactly one row
+#[test]
+fn test_get_job_applications_one() -> Result<(), Box<dyn std::error::Error>> {
+    let mut conn = get_memory_connection()?;
+
+    let id = 1;
+    let source = "Test source";
+    let company = "Test company";
+    let job_title = "Test job title";
+    let application_date = "2000-01-01";
+    let time_investment = 83; // 1:23
+    let human_response = HumanResponse::Rejection;
+    let human_response_date = "2000-01-02";
+    let application_website = "http://example.com";
+    let notes = "Test notes\nWith newline";
+
+    // Insert one job application with known fields
+    conn.execute(
+        "INSERT INTO job_applications (id, source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes) \
+        VALUES (:id, :source, :company, :job_title, :application_date, :time_investment, :human_response, :human_response_date, :application_website, :notes)",
+        named_params! {
+            ":id": id,
+            ":source": source,
+            ":company": company,
+            ":job_title": job_title,
+            ":application_date": application_date,
+            ":time_investment": time_investment,
+            ":human_response": human_response,
+            ":human_response_date": human_response_date,
+            ":application_website": application_website,
+            ":notes": notes,
+        }
+    )?;
+
+    assert_eq!(
+        conn.get_job_applications()?,
+        vec![JobApplication {
+            id,
+            source: source.to_string(),
+            company: company.to_string(),
+            job_title: job_title.to_string(),
+            application_date: Date::from_calendar_date(2000, Month::January, 1).unwrap(),
+            time_investment: Some(time_investment.seconds()),
+            human_response,
+            human_response_date: Some(Date::from_calendar_date(2000, Month::January, 2).unwrap()),
+            application_website: Some(application_website.to_string()),
+            notes: Some(notes.to_string()),
+        }],
+        "Incorrect job application vec returned"
+    );
+
+    Ok(())
+}
+
+/// Test [JobApplicationRepository::get_job_applications] where the table has multiple rows
+#[test]
+fn test_get_job_applications_many() -> Result<(), Box<dyn std::error::Error>> {
+    let mut conn = get_memory_connection()?;
+
+    let source = "Test source";
+    let company = "Test company";
+    let job_title = "Test job title";
+    let application_date = "2000-01-01";
+    let time_investment = 83; // 1:23
+    let human_response = HumanResponse::Rejection;
+    let human_response_date = "2000-01-02";
+    let application_website = "http://example.com";
+    let notes = "Test notes\nWith newline";
+
+    // Insert three job applications with known fields
+    // This will insert 3 copies of the same values, but that's unlikely to miss any bugs
+    conn.execute(
+        "INSERT INTO job_applications (id, source, company, job_title, application_date, time_investment, human_response, human_response_date, application_website, notes) \
+        VALUES (1, :source, :company, :job_title, :application_date, :time_investment, :human_response, :human_response_date, :application_website, :notes), \
+        (2, :source, :company, :job_title, :application_date, :time_investment, :human_response, :human_response_date, :application_website, :notes), \
+        (3, :source, :company, :job_title, :application_date, :time_investment, :human_response, :human_response_date, :application_website, :notes)",
+        named_params! {
+            ":source": source,
+            ":company": company,
+            ":job_title": job_title,
+            ":application_date": application_date,
+            ":time_investment": time_investment,
+            ":human_response": human_response,
+            ":human_response_date": human_response_date,
+            ":application_website": application_website,
+            ":notes": notes,
+        }
+    )?;
+
+    let mut returned_vec = conn.get_job_applications()?;
+
+    // Ensure the vector is sorted by id (ascending) because we are not testing order
+    returned_vec.sort_unstable_by_key(|o| o.id);
+
+    assert_eq!(
+        returned_vec,
+        vec![
+            JobApplication {
+                id: 1,
+                source: source.to_string(),
+                company: company.to_string(),
+                job_title: job_title.to_string(),
+                application_date: Date::from_calendar_date(2000, Month::January, 1).unwrap(),
+                time_investment: Some(time_investment.seconds()),
+                human_response,
+                human_response_date: Some(
+                    Date::from_calendar_date(2000, Month::January, 2).unwrap()
+                ),
+                application_website: Some(application_website.to_string()),
+                notes: Some(notes.to_string()),
+            },
+            JobApplication {
+                id: 2,
+                source: source.to_string(),
+                company: company.to_string(),
+                job_title: job_title.to_string(),
+                application_date: Date::from_calendar_date(2000, Month::January, 1).unwrap(),
+                time_investment: Some(time_investment.seconds()),
+                human_response,
+                human_response_date: Some(
+                    Date::from_calendar_date(2000, Month::January, 2).unwrap()
+                ),
+                application_website: Some(application_website.to_string()),
+                notes: Some(notes.to_string()),
+            },
+            JobApplication {
+                id: 3,
+                source: source.to_string(),
+                company: company.to_string(),
+                job_title: job_title.to_string(),
+                application_date: Date::from_calendar_date(2000, Month::January, 1).unwrap(),
+                time_investment: Some(time_investment.seconds()),
+                human_response,
+                human_response_date: Some(
+                    Date::from_calendar_date(2000, Month::January, 2).unwrap()
+                ),
+                application_website: Some(application_website.to_string()),
+                notes: Some(notes.to_string()),
+            },
+        ]
+    );
+
+    Ok(())
+}
+
+/// Test [JobApplicationRepository::get_pending_job_applications]
+///
+/// 3 job applications are inserted, but only the one where `human_response == None` should be returned.
+#[test]
+fn test_get_pending_job_applications() -> Result<(), Box<dyn std::error::Error>> {
+    let mut conn = get_memory_connection()?;
+
+    // Base job application
+    // We will only be checking id and human_response
+    let job_application = JobApplication {
+        id: 0,
+        source: "Test source".to_string(),
+        company: "Test company".to_string(),
+        job_title: "Test job title".to_string(),
+        application_date: Date::from_calendar_date(2000, Month::January, 1).unwrap(),
+        time_investment: None,
+        human_response: HumanResponse::None,
+        human_response_date: None,
+        application_website: None,
+        notes: None,
+    };
+
+    conn.execute(
+        "INSERT INTO job_applications (id, source, company, job_title, application_date, human_response) \
+        VALUES (1, :source, :company, :job_title, :application_date, :human_response1), \
+        (2, :source, :company, :job_title, :application_date, :human_response2), \
+        (3, :source, :company, :job_title, :application_date, :human_response3)",
+        named_params! {
+            ":source": job_application.source,
+            ":company": job_application.company,
+            ":job_title": job_application.job_title,
+            ":application_date": job_application.application_date,
+            ":human_response1": HumanResponse::None,
+            ":human_response2": HumanResponse::Rejection,
+            ":human_response3": HumanResponse::InterviewRequest
+        }
+    )?;
+
+    assert_eq!(
+        conn.get_pending_job_applications()?,
+        vec![JobApplication {
+            id: 1,
+            human_response: HumanResponse::None,
+            ..job_application
+        }],
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_get_job_application_by_id() -> Result<(), Box<dyn std::error::Error>> {
+    let mut conn = get_memory_connection()?;
+    Ok(())
+}
+
+#[test]
+fn test_search_job_applications() -> Result<(), Box<dyn std::error::Error>> {
+    let mut conn = get_memory_connection()?;
+    Ok(())
+}
+
+#[test]
+fn test_insert_job_application() -> Result<(), Box<dyn std::error::Error>> {
+    let mut conn = get_memory_connection()?;
+    Ok(())
+}
+
+#[test]
+fn test_update_human_response() -> Result<(), Box<dyn std::error::Error>> {
+    let mut conn = get_memory_connection()?;
+    Ok(())
+}
+
+#[test]
+fn test_update_job_application() -> Result<(), Box<dyn std::error::Error>> {
+    let mut conn = get_memory_connection()?;
+    Ok(())
+}
+
+#[test]
+fn test_update_job_application_partial() -> Result<(), Box<dyn std::error::Error>> {
+    let mut conn = get_memory_connection()?;
+    Ok(())
+}
+
+#[test]
+fn test_delete_job_application() -> Result<(), Box<dyn std::error::Error>> {
+    let mut conn = get_memory_connection()?;
+    Ok(())
+}
+
+fn get_memory_connection() -> Result<Connection, rusqlite::Error> {
+    let conn = Connection::open_in_memory()?;
+
+    conn.execute(include_str!("../resources/sqlite_table_definition.sql"), ())?;
+
+    Ok(conn)
+}

--- a/repository/tests/sqlite_tests.rs
+++ b/repository/tests/sqlite_tests.rs
@@ -1,9 +1,11 @@
 //! Integration tests for the SQLite implementation
 
+#![cfg(not(feature = "mysql"))]
+
 use rusqlite::{named_params, Connection};
 use time::{ext::NumericalDuration as _, Date, Month};
 
-use crate::{
+use repository::{
     job_application_model::{
         HumanResponse, JobApplication, JobApplicationField, PartialJobApplication,
     },
@@ -1002,7 +1004,10 @@ fn test_delete_job_application_invalid_id() -> Result<(), Box<dyn std::error::Er
 fn get_memory_connection() -> Result<Connection, rusqlite::Error> {
     let conn = Connection::open_in_memory()?;
 
-    conn.execute(include_str!("../resources/sqlite_table_definition.sql"), ())?;
+    conn.execute(
+        include_str!("../src/resources/sqlite_table_definition.sql"),
+        (),
+    )?;
 
     Ok(conn)
 }


### PR DESCRIPTION
Adds an optional SQLite backend and makes that backend the default. The original MySQL backend can still be used by compiling with `--features repository/mysql`.

This change also makes the ".env" file optional. Before this change both executables would panic if the .env file was not found. All frontends and all backends now attempt to find the file, but will not immediately panic if it is not found. The MySQL repository crate will print warnings for missing environment variables, but will not panic unless the default configuration produces an error.

Also the repository crate now has testing (for SQLite only).

closes #24