### PR TITLE
36 minor UI improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["cli", "gui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.6.3"
+version = "0.7.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/stdonnelly/ats-tracking-system"

--- a/gui/view/components/search_bar.slint
+++ b/gui/view/components/search_bar.slint
@@ -32,6 +32,15 @@ export component SearchBar inherits HorizontalBox {
     // Search by source, company, or human response
     search-box := LineEdit {
         placeholder-text: "Search by text";
+        // Pressing [ENTER] while focused on the search box will trigger the search
+        accepted(text) => {
+            search(
+                // Only use human response when the index is valid and the selected value is not "- Filter by response -"
+                human-response.current-index > 0,
+                Logic.string-to-human-response(human-response.current-value),
+                text
+            );
+        }
     }
 
     search-button := Button {

--- a/gui/view/components/sidebar.slint
+++ b/gui/view/components/sidebar.slint
@@ -11,7 +11,7 @@ export component Sidebar inherits GridLayout {
     out property <length> sidebar-min-width: self.spacing + (2 * self.padding) + self.col-1-min-width + source-input.min-width;
     
     // Callbacks to be defined elsewhere
-    callback submit-job-application <=> job-application-submit.clicked;
+    callback submit-job-application();
     callback new-job-application();
     callback delete-job-application(int);
     pure callback date-diff <=> Logic.date-diff;
@@ -161,7 +161,7 @@ export component Sidebar inherits GridLayout {
         }
 
         // Custom time input using a horizontal layout of `LineEdit`s
-        HorizontalLayout {
+        time-investment := HorizontalLayout {
             // This is used to update the selected job application after text edit changes
             function store-time() {
                 selected-job-application.time-investment = (time-investment-min.text.to-float() * 60) + time-investment-sec.text.to-float();
@@ -179,8 +179,14 @@ export component Sidebar inherits GridLayout {
                 height: 2.5rem;
                 text: floor(selected-job-application.time-investment / 60);
                 input-type: number;
-                edited(_) => {
-                    store-time();
+                changed has-focus => {
+                    if (self.has-focus) {
+                        // Select the text when the user clicks on the field
+                        self.select-all();
+                    } else {
+                        // When something else is selected, store the time in the selected job application and normalize
+                        store-time();
+                    }
                 }
             }
 
@@ -194,8 +200,14 @@ export component Sidebar inherits GridLayout {
                 height: 2.5rem;
                 text: mod(selected-job-application.time-investment, 60);
                 input-type: number;
-                edited(_) => {
-                    store-time();
+                changed has-focus => {
+                    if (self.has-focus) {
+                        // Select the text when the user clicks on the field
+                        self.select-all();
+                    } else {
+                        // When something else is selected, store the time in the selected job application and normalize
+                        store-time();
+                    }
                 }
             }
         }
@@ -351,6 +363,12 @@ export component Sidebar inherits GridLayout {
 
             job-application-submit := StandardButton {
                 kind: apply;
+                clicked => {
+                    // Store and normalize the time
+                    time-investment.store-time();
+                    // Send the selected job application to the callback
+                    submit-job-application();
+                }
             }
         }
     }

--- a/gui/view/components/sidebar.slint
+++ b/gui/view/components/sidebar.slint
@@ -325,6 +325,7 @@ export component Sidebar inherits GridLayout {
             // Set the height of this element to the default `min-value` of `Button`.
             // This is necessary because `StandardButton` sometimes makes weird changes to the height
             height: job-application-new.min-height;
+            alignment: space-between;
 
             job-application-new := Button {
                 text: "New";

--- a/gui/view/components/table.slint
+++ b/gui/view/components/table.slint
@@ -16,7 +16,12 @@ export component JobApplicationTable inherits StandardTableView {
         + self.columns[7].min-width
         + self.columns[8].min-width
         + self.columns[9].min-width
-        + self.columns[10].min-width;
+        + self.columns[10].min-width
+        /* This is the extra width of the window needed to display the vertical scrollbar in Qt.
+           The scrollbar is actually narrower than this, but, because the table width is 80% of the window width, the window must grow more.
+           This will cause the window to be larger than necessary where the scrollbar is narrower or has no width.
+           This isn't a huge concern because this is only the preferred width */
+        + 42px;
 
     current-row-changed(current-row) => {
         // Call the backend code to change the sidebar


### PR DESCRIPTION
- Pressing [ENTER] when the search box has focus will now execute the same action that is executed when the search button is pressed. The drop-down menu for the response type does not have this feature, but I don't feel like it's necessary or helpful.
- The normalization of the "Time Taken" input on the sidebar now normalizes itself when either of the `LineEdit`s are unfocused. This makes inputting more than 59 seconds easier. The normalization also happens when the "Apply" button is pressed because this does not count as an unfocus.
- The "Time Taken" inputs will now select all on focus, instead of trying to prepend the existing number. These text boxes start with a "0" because the empty string is not a number. Usually, the user wants to overwrite this.
- The scroll bar is now accounted for on Qt (the solution is kind of a hack, though).
- The "New," "Delete," and "Apply" buttons now spread apart instead of growing with the sidebar. This was necessary because the `StandardButton` element does not stretch on the winit versions.

closes #36